### PR TITLE
Added New CSV Format

### DIFF
--- a/src/core/parsing/Parser.py
+++ b/src/core/parsing/Parser.py
@@ -29,18 +29,23 @@ def getDataFromColumn(df, columnPointDict):
     y_idx = int(columnPointDict.get("y", -1))
     c_idx = int(columnPointDict.get("conf", -1))
 
-    # If any required column is missing, return a NaN point of the correct length
+    # If x/y are missing, return a NaN point of the correct length
     # instead of accidentally indexing the last column (pandas iloc[-1]).
-    if x_idx < 0 or y_idx < 0 or c_idx < 0:
+    if x_idx < 0 or y_idx < 0:
         return _empty_point(n_frames)
 
     xColumn = pd.to_numeric(df.iloc[1:, x_idx], errors="coerce")
     yColumn = pd.to_numeric(df.iloc[1:, y_idx], errors="coerce")
-    confColumn = pd.to_numeric(df.iloc[1:, c_idx], errors="coerce")
+    # XY-only exports omit likelihood; treat confidence as fully trusted so downstream
+    # filters (spine plots, optional min_conf gates) do not drop frames.
+    if c_idx < 0:
+        conf_vals = np.ones(n_frames, dtype=float)
+    else:
+        conf_vals = pd.to_numeric(df.iloc[1:, c_idx], errors="coerce").values
     return {
         "x": xColumn.values,
         "y": yColumn.values,
-        "conf": confColumn.values
+        "conf": conf_vals,
     }
 
 

--- a/src/core/parsing/body_part_detector.py
+++ b/src/core/parsing/body_part_detector.py
@@ -77,8 +77,8 @@ def detect_body_parts(csv_path: str) -> BodyPartDetectionResult:
     """
     Automatically detect body parts from a CSV file.
 
-    Supports two CSV formats:
-    1. Raw DLC output: has 'bodyparts' and 'coords' header rows
+    Supports CSV formats:
+    1. Raw DLC output: has `scorer` / `bodyparts` / `coords` header rows (classic x,y,likelihood or XY-only x,y per part)
     2. Enriched output: has prefixed columns like Spine_Head_x, LeftFin_LF1_x
 
     Args:
@@ -234,14 +234,24 @@ def _detect_format_from_columns(columns: List[str]) -> str:
 # Private: DLC raw CSV detection
 # ---------------------------------------------------------------------------
 
+def _dlc_coord_stride_from_coords_row(coords_row: List[Any]) -> int:
+    """
+    Return 3 for classic DLC (x, y, likelihood) or 2 for XY-only exports (x, y).
+
+    Detection is based on the coords header row (row 2 in a raw DLC file).
+    """
+    lowered = [str(v).strip().lower() for v in coords_row]
+    return 3 if any(c == "likelihood" for c in lowered) else 2
+
+
 def _detect_from_dlc_raw(path: Path, warn_list: List[str]) -> BodyPartDetectionResult:
     """
     Detect body parts from a raw DLC CSV file.
 
     DLC CSV structure:
         Row 0: scorer    - model name repeated
-        Row 1: bodyparts - body part name repeated 3x per part
-        Row 2: coords    - x, y, likelihood repeated
+        Row 1: bodyparts - body part name repeated per coordinate column
+        Row 2: coords    - x, y, [likelihood] repeated for each bodypart
         Row 3+: data
     """
     try:
@@ -249,7 +259,10 @@ def _detect_from_dlc_raw(path: Path, warn_list: List[str]) -> BodyPartDetectionR
     except Exception as exc:
         raise ValueError(f"Could not read DLC CSV at {path}: {exc}")
 
-    # Row 1 contains body part names (repeated 3x each: x, y, likelihood)
+    coords_header = raw.iloc[2, 1:].tolist()  # Skip first column (label)
+    stride = _dlc_coord_stride_from_coords_row(coords_header)
+
+    # Row 1 contains body part names (repeated once per coordinate column)
     bodyparts_row = raw.iloc[1, 1:].tolist()  # Skip first column (label)
 
     seen: Set[str] = set()
@@ -268,11 +281,18 @@ def _detect_from_dlc_raw(path: Path, warn_list: List[str]) -> BodyPartDetectionR
             ordered_parts.append(name_str)
             # Column index offset by 1 for the label column
             col_offset = idx + 1
-            column_map[name_str] = {
-                "x": col_offset,
-                "y": col_offset + 1,
-                "conf": col_offset + 2,
-            }
+            if stride == 3:
+                column_map[name_str] = {
+                    "x": col_offset,
+                    "y": col_offset + 1,
+                    "conf": col_offset + 2,
+                }
+            else:
+                column_map[name_str] = {
+                    "x": col_offset,
+                    "y": col_offset + 1,
+                    "conf": -1,
+                }
 
     if not ordered_parts:
         warn_list.append("No body parts detected in the DLC CSV bodyparts row.")
@@ -296,7 +316,8 @@ def _detect_from_dlc_df(
     (the bodyparts row as header), which is how parser.py loads files.
 
     Column names look like:
-        Head, Head.1, Head.2, LE, LE.1, LE.2 ...
+        Head, Head.1, Head.2, LE, LE.1, LE.2 ... (with likelihood)
+        or Head, Head.1, LE, LE.1 ... (XY-only; no .2 likelihood column)
     The base name (without .N suffix) is the body part name.
     """
     columns = list(df.columns)
@@ -334,9 +355,9 @@ def _detect_from_dlc_df(
                 "conf": conf_idx,
             }
 
-            if y_idx == -1 or conf_idx == -1:
+            if y_idx == -1:
                 warn_list.append(
-                    f"Body part '{col_str}' is missing y or confidence columns."
+                    f"Body part '{col_str}' is missing y column."
                 )
 
     if not ordered_parts:

--- a/src/core/parsing/test_body_part_detector.py
+++ b/src/core/parsing/test_body_part_detector.py
@@ -68,6 +68,45 @@ def create_dlc_raw_csv(
 
     return tmp.name
 
+
+def create_dlc_raw_csv_xy_only(
+    body_parts: List[str],
+    n_frames: int = 5
+) -> str:
+    """Create a temporary raw DLC CSV with two columns (x, y) per bodypart."""
+    scorer_row = ["scorer"] + ["DLC_model"] * (len(body_parts) * 2)
+    bodyparts_row = ["bodyparts"]
+    coords_row = ["coords"]
+
+    for part in body_parts:
+        bodyparts_row += [part, part]
+        coords_row += ["x", "y"]
+
+    data_rows = []
+    for i in range(n_frames):
+        row = [str(i)]
+        for _ in body_parts:
+            row += [
+                str(round(100.0 + i, 2)),
+                str(round(200.0 + i, 2)),
+            ]
+        data_rows.append(row)
+
+    tmp = tempfile.NamedTemporaryFile(
+        mode="w", suffix=".csv", delete=False, newline=""
+    )
+    import csv
+    writer = csv.writer(tmp)
+    writer.writerow(scorer_row)
+    writer.writerow(bodyparts_row)
+    writer.writerow(coords_row)
+    for row in data_rows:
+        writer.writerow(row)
+    tmp.close()
+
+    return tmp.name
+
+
 def create_enriched_csv(
     body_parts_by_group: Dict[str, List[str]],
     n_frames: int = 5
@@ -200,7 +239,7 @@ class TestDetectBodyParts:
         assert result.source_type == "enriched"
 
     def test_column_map_has_xyz_for_each_part(self, dlc_raw_csv_path):
-        """Each body part should have x, y, conf in column map."""
+        """Each body part should have x, y, conf file indices (classic DLC)."""
         result = detect_body_parts(dlc_raw_csv_path)
 
         for part, indices in result.column_map.items():
@@ -208,6 +247,18 @@ class TestDetectBodyParts:
             assert "y" in indices
             assert "conf" in indices
             assert isinstance(indices["x"], int)
+            assert indices["conf"] >= 1
+
+    def test_xy_only_column_map_omits_conf_index(self):
+        """XY-only raw DLC maps conf to -1 (no likelihood column on disk)."""
+        path = create_dlc_raw_csv_xy_only(["Head", "LF1"])
+        try:
+            result = detect_body_parts(path)
+            assert result.column_map["Head"]["conf"] == -1
+            assert result.column_map["LF1"]["conf"] == -1
+            assert result.column_map["Head"]["y"] == result.column_map["Head"]["x"] + 1
+        finally:
+            os.unlink(path)
 
     def test_file_not_found_raises_error(self):
         """Should raise FileNotFoundError for non-existent file."""
@@ -336,6 +387,18 @@ class TestFromDataFrame:
         result = detect_body_parts_from_dataframe(dlc_dataframe)
         assert isinstance(result, BodyPartDetectionResult)
         assert len(result.all_body_parts) > 0
+
+    def test_dlc_dataframe_xy_only(self):
+        """DataFrame from XY-only DLC should report conf index -1 in column_map."""
+        path = create_dlc_raw_csv_xy_only(["Head", "ET"])
+        try:
+            df = pd.read_csv(path, header=1)
+            result = detect_body_parts_from_dataframe(df, source_type="dlc_raw")
+            assert "Head" in result.all_body_parts
+            assert result.column_map["Head"]["conf"] == -1
+            assert result.column_map["Head"]["y"] == result.column_map["Head"]["x"] + 1
+        finally:
+            os.unlink(path)
 
     def test_auto_detects_dlc_format(self, dlc_dataframe):
         """Auto detection should identify DLC format from column names."""

--- a/src/core/validation/csv_verifier.py
+++ b/src/core/validation/csv_verifier.py
@@ -30,8 +30,9 @@ def verify_deeplabcut_csv(file_path, img_width=None, img_height=None):
         bp_groups.setdefault(bp, []).append(coord)
 
     for bp, coord_list in bp_groups.items():
-        expected = ["x", "y", "likelihood"]
-        if coord_list != expected:
+        expected_full = ["x", "y", "likelihood"]
+        expected_xy = ["x", "y"]
+        if coord_list not in (expected_full, expected_xy):
             errors.append(
                 f"[ERROR] Bodypart '{bp}' has wrong columns: {coord_list}")
 

--- a/tests/unit/core/calculations/test_Parser.py
+++ b/tests/unit/core/calculations/test_Parser.py
@@ -47,3 +47,32 @@ def test_parse_dlc_csv_shapes_and_values(tmp_path: Path):
     npt.assert_allclose(parsed["right_fin"][0]["x"], np.array([30.0, 31.0]))
     assert parsed["tailPoints"] == ["LF1", "LE"]
     npt.assert_allclose(parsed["tail"][0]["conf"], np.array([0.7, 0.71]))
+
+
+def test_parse_dlc_csv_xy_only_defaults_confidence(tmp_path: Path):
+    """XY-only DLC (no likelihood column): parse x/y and use conf=1.0."""
+    csv_path = tmp_path / "sample_xy.csv"
+    csv_path.write_text(
+        "scorer,DLC,DLC,DLC,DLC,DLC,DLC\n"
+        "bodyparts,Head,Head,LE,LE,LF1,LF1\n"
+        "coords,x,y,x,y,x,y\n"
+        "0,10,20,30,40,50,60\n"
+        "1,11,21,31,41,51,61\n"
+    )
+
+    config = {
+        "points": {
+            "spine": ["Head", "LE", "LF1"],
+            "left_fin": ["LF1"],
+            "right_fin": ["LE"],
+            "head": {"pt1": "Head", "pt2": "LE"},
+            "tail": ["LF1", "LE"],
+        }
+    }
+
+    parsed = parse_dlc_csv(str(csv_path), config)
+
+    npt.assert_allclose(parsed["spine"][0]["x"], np.array([10.0, 11.0]))
+    npt.assert_allclose(parsed["spine"][0]["y"], np.array([20.0, 21.0]))
+    npt.assert_allclose(parsed["spine"][0]["conf"], np.array([1.0, 1.0]))
+    npt.assert_allclose(parsed["left_fin"][0]["conf"], np.array([1.0, 1.0]))

--- a/tests/unit/core/validation/unit_test.py
+++ b/tests/unit/core/validation/unit_test.py
@@ -37,6 +37,23 @@ def test_valid_csv(tmp_path: Path):
     assert warnings == []
 
 
+def test_valid_csv_xy_only(tmp_path: Path):
+    path = tmp_path / "xy.csv"
+    path.write_text(
+        "\n".join(
+            [
+                "scorer,body1,body1",
+                "bodyparts,body1,body1",
+                "coords,x,y",
+                "frame0,10,20",
+            ]
+        )
+    )
+    errors, warnings = verify_deeplabcut_csv(str(path))
+    assert errors == []
+    assert warnings == []
+
+
 def test_wrong_columns(tmp_path: Path):
     path = tmp_path / "wrong_columns.csv"
     path.write_text(


### PR DESCRIPTION
## Summary
This adds the new CSV Format to accepted input for the app, and treats input as if it has 100% confidence to replace the "confidence" column when it isn't in the CSV. Kept original functionality and will behave the same as before with CSVs that have confidence columns. (Note: Confidence is used when machine learning is used to make point labeling easier, where it labels its certainty in picking the right X, Y point in the input.)

## Testing
- [ ] `pytest`
- [ ] Manual UI walkthrough (describe)
- [ ] Other (describe)

## Checklist
- [ ] Docs updated (README/how-to/notes)
- [ ] Tests added/updated
- [ ] No breaking changes without migration notes
