### PR TITLE
add interactive features for graphs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,3 +54,9 @@ data/local/
 
 # results
 results/
+.venv/
+venv/
+source/
+*.pyc
+__pycache__/
+*.egg-info/

--- a/src/app_platform/paths.py
+++ b/src/app_platform/paths.py
@@ -176,6 +176,88 @@ def relocate_flat_registry_path_to_bundle(missing_path_str: str) -> str | None:
         return str(bundle_jp)
 
 
+def resolve_graph_asset_path(stored_path_str: str, session_name: str | None = None) -> str | None:
+    """Return an on-disk path for a session / export graph file if it exists.
+
+    Session JSON stores absolute paths. When the repo is copied or renamed (e.g.
+    ``…/Desktop/cv_zebrafish`` → ``…/Desktop/Zebrafish/cv_zebrafish``), those paths
+    go stale. This helper re-resolves under the *current* :func:`project_root` and
+    the session bundle folder when possible.
+    """
+    if not stored_path_str:
+        return None
+    p = Path(stored_path_str).expanduser()
+    try:
+        if p.is_file():
+            return str(p.resolve())
+    except OSError:
+        if p.is_file():
+            return str(p)
+
+    # Same path relative to repo top-level dirs (data/, configs/, …) after moving the clone.
+    _TOP = frozenset({"data", "configs", "assets", "src"})
+    try:
+        parts = p.parts
+        idx = next(i for i, part in enumerate(parts) if part.lower() in _TOP)
+        rel = Path(*parts[idx:])
+        cand = project_root() / rel
+        if cand.is_file():
+            try:
+                return str(cand.resolve())
+            except OSError:
+                return str(cand)
+    except (StopIteration, OSError, ValueError):
+        pass
+
+    if session_name:
+        bundle = session_bundle_dir(session_name)
+        name_lower = session_name.lower()
+        try:
+            for i, part in enumerate(p.parts):
+                if part.lower() == name_lower:
+                    tail = Path(*p.parts[i + 1 :])
+                    if tail.parts:
+                        cand = bundle / tail
+                        if cand.is_file():
+                            try:
+                                return str(cand.resolve())
+                            except OSError:
+                                return str(cand)
+                    break
+        except (OSError, ValueError):
+            pass
+        cand = bundle / p.name
+        if cand.is_file():
+            try:
+                return str(cand.resolve())
+            except OSError:
+                return str(cand)
+
+    return None
+
+
+def resolve_folder_graphs_asset_paths(folder_graphs: dict, session_name: str) -> dict:
+    """Rebuild *folder_graphs* with assets re-pointed via :func:`resolve_graph_asset_path`."""
+    out: dict = {}
+    for folder_path, cfgs in (folder_graphs or {}).items():
+        new_cfgs: dict = {}
+        for config_path, per_csv in (cfgs or {}).items():
+            new_per_csv: dict = {}
+            for csv_file, assets in (per_csv or {}).items():
+                new_assets: list = []
+                for a in assets or []:
+                    r = resolve_graph_asset_path(a, session_name)
+                    if r:
+                        new_assets.append(r)
+                if new_assets:
+                    new_per_csv[csv_file] = new_assets
+            if new_per_csv:
+                new_cfgs[config_path] = new_per_csv
+        if new_cfgs:
+            out[folder_path] = new_cfgs
+    return out
+
+
 def canonical_session_json_path(path_str: str) -> str:
     """Single on-disk path for a session: prefer bundle ``…/<name>/session.json`` over legacy flat ``…/<name>.json``."""
     try:
@@ -275,6 +357,8 @@ __all__ = [
     "migrate_flat_session_json_into_bundle_dirs",
     "relocate_flat_registry_path_to_bundle",
     "canonical_session_json_path",
+    "resolve_graph_asset_path",
+    "resolve_folder_graphs_asset_paths",
     "local_data_dir",
     "session_registry_path",
 ]

--- a/src/core/validation/csv_verifier.py
+++ b/src/core/validation/csv_verifier.py
@@ -30,8 +30,15 @@ def verify_deeplabcut_csv(file_path, img_width=None, img_height=None):
         bp_groups.setdefault(bp, []).append(coord)
 
     for bp, coord_list in bp_groups.items():
-        expected = ["x", "y", "likelihood"]
-        if coord_list != expected:
+        
+        ##CHANGED THIS - Sahana
+        expected_full = ["x", "y", "likelihood"]
+        expected_minimal = ["x", "y"]
+
+
+        ##ALSO CHANED THIS
+        # from if coord_list != expected: to the folloing
+        if coord_list not in (expected_full, expected_minimal):
             errors.append(
                 f"[ERROR] Bodypart '{bp}' has wrong columns: {coord_list}")
 

--- a/src/session/session.py
+++ b/src/session/session.py
@@ -5,7 +5,12 @@ from pathlib import Path
 from PyQt5.QtCore import pyqtSignal, QObject
 from PyQt5.QtWidgets import QMessageBox
 
-from app_platform.paths import SESSION_JSON_FILENAME, session_bundle_dir
+from app_platform.paths import (
+    SESSION_JSON_FILENAME,
+    resolve_folder_graphs_asset_paths,
+    resolve_graph_asset_path,
+    session_bundle_dir,
+)
 
 class Session(QObject):
     session_updated = pyqtSignal()
@@ -254,6 +259,17 @@ class Session(QObject):
             self.last_config_path = None
         self.session_updated.emit()
 
+def _session_resolved_path(stored: str, session_name: str) -> str:
+    """Prefer a path that exists under the current repo clone, else *stored*."""
+    if not stored:
+        return stored
+    r = resolve_graph_asset_path(stored, session_name)
+    if r:
+        return r
+    r = resolve_graph_asset_path(stored, None)
+    return r or stored
+
+
 def load_session_from_json(json_path):
     """Load a session from a JSON file."""
     try:
@@ -272,18 +288,26 @@ def load_session_from_json(json_path):
     last_scene = data.get("last_scene") or "Verify"
     session.last_scene = last_scene
     session.calculation_has_run = bool(data.get("calculation_has_run", False))
-    session.last_csv_path = data.get("last_csv_path")
-    session.last_config_path = data.get("last_config_path")
+    lcsv = data.get("last_csv_path")
+    session.last_csv_path = _session_resolved_path(lcsv, session_name) if lcsv else None
+    lcfg = data.get("last_config_path")
+    session.last_config_path = _session_resolved_path(lcfg, session_name) if lcfg else None
     session.csv_folders = data.get("csv_folders") or {}
-    session.folder_graphs = data.get("folder_graphs") or {}
+    session.folder_graphs = resolve_folder_graphs_asset_paths(
+        data.get("folder_graphs") or {}, session_name
+    )
 
     csvs = data.get("csvs", {})
     for csv_path, configs in csvs.items():
-        session.addCSV(csv_path)
+        csv_id = _session_resolved_path(csv_path, session_name)
+        session.addCSV(csv_id)
         for config_path, graphs in configs.items():
-            session.addConfigToCSV(csv_path, config_path)
+            cfg_id = _session_resolved_path(config_path, session_name)
+            session.addConfigToCSV(csv_id, cfg_id)
             for graph_path in graphs:
-                session.addGraphToConfig(config_path, graph_path)
+                resolved = resolve_graph_asset_path(graph_path, session_name)
+                if resolved:
+                    session.addGraphToConfig(cfg_id, resolved)
 
     return session
 

--- a/src/ui/components/InteractiveGraph.py
+++ b/src/ui/components/InteractiveGraph.py
@@ -18,23 +18,37 @@ Usage
 
 from __future__ import annotations
 
+import os
+import tempfile
+from pathlib import Path
 from typing import Optional
 
+import plotly
 import plotly.graph_objs as go
 import plotly.io as pio
 
-from PyQt5.QtCore import Qt, QUrl
+from PyQt5.QtCore import QTimer, Qt, QUrl
 from PyQt5.QtWidgets import QLabel, QSizePolicy, QStackedWidget, QVBoxLayout, QWidget
 
 # ---------------------------------------------------------------------------
 # Optional QtWebEngine import
 # ---------------------------------------------------------------------------
 try:
-    from PyQt5.QtWebEngineWidgets import QWebEngineView
+    from PyQt5.QtWebEngineWidgets import QWebEngineSettings, QWebEngineView
 
     _WEBENGINE_AVAILABLE = True
 except ImportError:
     _WEBENGINE_AVAILABLE = False
+
+
+# Plotly ≥2.3 uses :focus-visible in modebar CSS injected via insertRule(). Older
+# Chromium (Qt 5 WebEngine) rejects that selector and aborts Plotly startup, so
+# we ship a byte-patched copy of plotly.min.js (cached under %TEMP%) for previews.
+_PLOTLY_QWEBENGINE_PATCHES: tuple[tuple[bytes, bytes], ...] = (
+    (b'"X .modebar-btn:focus-visible"', b'"X .modebar-btn:focus"'),
+    (b"button:focus:focus-visible", b"button:focus"),
+    (b"button:focus:not(:focus-visible)", b"button:focus:not(:focus)"),
+)
 
 
 # ---------------------------------------------------------------------------
@@ -56,6 +70,7 @@ class InteractiveGraph(QWidget):
         super().__init__(parent)
         self._figure: Optional[go.Figure] = None
         self._html_cache: Optional[str] = None
+        self._preview_html_path: Optional[Path] = None
 
         self._build_ui()
 
@@ -74,8 +89,10 @@ class InteractiveGraph(QWidget):
         self._html_cache = html
 
         if _WEBENGINE_AVAILABLE:
-            # Load the HTML string directly into the web view.
-            self._web_view.setHtml(html, QUrl("about:blank"))
+            # setHtml() uses a data:-like origin; Plotly's large inline bundle often
+            # fails to run there, leaving a blank white view. file:// + load() is reliable.
+            path = self._write_preview_html(html)
+            self._web_view.load(QUrl.fromLocalFile(str(path.resolve())))
             self._stack.setCurrentWidget(self._web_view)
         else:
             self._fallback_label.setText(
@@ -93,7 +110,7 @@ class InteractiveGraph(QWidget):
         self._figure = None
         self._html_cache = None
         if _WEBENGINE_AVAILABLE:
-            self._web_view.setHtml("", QUrl("about:blank"))
+            self._web_view.setUrl(QUrl("about:blank"))
             self._stack.setCurrentWidget(self._web_view)
         else:
             self._fallback_label.setText("Select a graph on the left.")
@@ -121,6 +138,11 @@ class InteractiveGraph(QWidget):
             self._web_view.setSizePolicy(
                 QSizePolicy.Expanding, QSizePolicy.Expanding
             )
+            ws = self._web_view.settings()
+            ws.setAttribute(QWebEngineSettings.JavascriptEnabled, True)
+            ws.setAttribute(QWebEngineSettings.LocalContentCanAccessFileUrls, True)
+            ws.setAttribute(QWebEngineSettings.ErrorPageEnabled, True)
+            self._web_view.loadFinished.connect(self._on_preview_load_finished)
             self._stack.addWidget(self._web_view)
         else:
             # Placeholder so the stack always has at least one widget
@@ -140,12 +162,70 @@ class InteractiveGraph(QWidget):
         else:
             self._stack.setCurrentWidget(self._fallback_label)
 
+    def resizeEvent(self, event) -> None:  # type: ignore[no-untyped-def]
+        super().resizeEvent(event)
+        if _WEBENGINE_AVAILABLE:
+            # Plotly sometimes measures a 0×0 container on first paint; refresh after resize.
+            QTimer.singleShot(0, self._resize_plotly_in_view)
+
+    def _write_preview_html(self, html: str) -> Path:
+        if self._preview_html_path is None:
+            self._preview_html_path = Path(tempfile.gettempdir()) / (
+                f"cv_zebrafish_plotly_{os.getpid()}_{id(self)}.html"
+            )
+        self._preview_html_path.write_text(html, encoding="utf-8")
+        return self._preview_html_path
+
+    def _on_preview_load_finished(self, ok: bool) -> None:
+        if ok:
+            self._resize_plotly_in_view()
+
+    def _resize_plotly_in_view(self) -> None:
+        if not _WEBENGINE_AVAILABLE or self._web_view is None:
+            return
+        js = (
+            "(() => { try { "
+            "var gd = document.querySelector('.plotly-graph-div') "
+            "|| document.querySelector('.js-plotly-plot'); "
+            "if (window.Plotly && Plotly.Plots && gd) { Plotly.Plots.resize(gd); } "
+            "} catch (e) {} })();"
+        )
+        self._web_view.page().runJavaScript(js)
+
+    @staticmethod
+    def _patched_plotly_js_uri() -> str:
+        """plotly.min.js with :focus-visible removed for Qt WebEngine compatibility."""
+        pkg = Path(plotly.__file__).resolve().parent
+        src = pkg / "package_data" / "plotly.min.js"
+        dest = Path(tempfile.gettempdir()) / "cv_zebrafish_plotly_qwebengine.min.js"
+        need_write = True
+        if dest.is_file():
+            try:
+                need_write = (
+                    dest.stat().st_mtime < src.stat().st_mtime
+                    or dest.stat().st_size == 0
+                )
+            except OSError:
+                need_write = True
+        if need_write:
+            data = src.read_bytes()
+            for old, new in _PLOTLY_QWEBENGINE_PATCHES:
+                data = data.replace(old, new)
+            dest.write_bytes(data)
+        return dest.resolve().as_uri()
+
     @staticmethod
     def _figure_to_html(fig: go.Figure) -> str:
         """Convert a Plotly figure to a self-contained HTML string."""
+        view = go.Figure(fig)
+        if view.layout.height is None:
+            view.update_layout(height=560, autosize=True)
         return pio.to_html(
-            fig,
-            include_plotlyjs="cdn",   # loads Plotly.js from CDN (~3 MB, cached)
+            view,
+            # External patched script (file://): inline bundle still trips old Chromium
+            # on :focus-visible in insertRule; patched copy matches the Python plotly
+            # version and loads next to the preview HTML.
+            include_plotlyjs=InteractiveGraph._patched_plotly_js_uri(),
             full_html=True,
             config={
                 "scrollZoom": True,       # mouse-wheel zoom

--- a/src/ui/components/InteractiveGraph.py
+++ b/src/ui/components/InteractiveGraph.py
@@ -1,0 +1,164 @@
+"""
+InteractiveGraph.py
+-------------------
+A PyQt5 widget that renders a Plotly figure as an interactive HTML page
+using QWebEngineView (zoom, pan, hover tooltips built-in via Plotly.js).
+
+Falls back gracefully to a plain QLabel with an error message if
+QtWebEngineWidgets is unavailable.
+
+Usage
+-----
+    from src.ui.components.InteractiveGraph import InteractiveGraph
+
+    widget = InteractiveGraph(parent)
+    widget.set_figure(fig)          # fig is a plotly go.Figure
+    widget.clear()                  # reset to blank state
+"""
+
+from __future__ import annotations
+
+from typing import Optional
+
+import plotly.graph_objs as go
+import plotly.io as pio
+
+from PyQt5.QtCore import Qt, QUrl
+from PyQt5.QtWidgets import QLabel, QSizePolicy, QStackedWidget, QVBoxLayout, QWidget
+
+# ---------------------------------------------------------------------------
+# Optional QtWebEngine import
+# ---------------------------------------------------------------------------
+try:
+    from PyQt5.QtWebEngineWidgets import QWebEngineView
+
+    _WEBENGINE_AVAILABLE = True
+except ImportError:
+    _WEBENGINE_AVAILABLE = False
+
+
+# ---------------------------------------------------------------------------
+# Public widget
+# ---------------------------------------------------------------------------
+
+
+class InteractiveGraph(QWidget):
+    """
+    Displays a Plotly figure interactively (zoom / pan / hover) when
+    PyQtWebEngine is available, or falls back to a static error label.
+
+    Parameters
+    ----------
+    parent : QWidget, optional
+    """
+
+    def __init__(self, parent: Optional[QWidget] = None) -> None:
+        super().__init__(parent)
+        self._figure: Optional[go.Figure] = None
+        self._html_cache: Optional[str] = None
+
+        self._build_ui()
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
+    def set_figure(self, fig: go.Figure) -> None:
+        """Render *fig* as an interactive Plotly chart inside the widget."""
+        if not isinstance(fig, go.Figure):
+            self.clear()
+            return
+
+        self._figure = fig
+        html = self._figure_to_html(fig)
+        self._html_cache = html
+
+        if _WEBENGINE_AVAILABLE:
+            # Load the HTML string directly into the web view.
+            self._web_view.setHtml(html, QUrl("about:blank"))
+            self._stack.setCurrentWidget(self._web_view)
+        else:
+            self._fallback_label.setText(
+                "Interactive graphs require PyQtWebEngine.\n"
+                "Install it with:\n"
+                "  pip install PyQtWebEngine\n"
+                "or:\n"
+                "  conda install -c conda-forge pyqtwebengine\n\n"
+                "Restart the app after installing."
+            )
+            self._stack.setCurrentWidget(self._fallback_label)
+
+    def clear(self) -> None:
+        """Reset the widget to its empty / placeholder state."""
+        self._figure = None
+        self._html_cache = None
+        if _WEBENGINE_AVAILABLE:
+            self._web_view.setHtml("", QUrl("about:blank"))
+            self._stack.setCurrentWidget(self._web_view)
+        else:
+            self._fallback_label.setText("Select a graph on the left.")
+            self._stack.setCurrentWidget(self._fallback_label)
+
+    @property
+    def figure(self) -> Optional[go.Figure]:
+        """Return the currently displayed Plotly figure (or None)."""
+        return self._figure
+
+    # ------------------------------------------------------------------
+    # Private helpers
+    # ------------------------------------------------------------------
+
+    def _build_ui(self) -> None:
+        layout = QVBoxLayout(self)
+        layout.setContentsMargins(0, 0, 0, 0)
+        layout.setSpacing(0)
+
+        self._stack = QStackedWidget()
+        layout.addWidget(self._stack)
+
+        if _WEBENGINE_AVAILABLE:
+            self._web_view = QWebEngineView()
+            self._web_view.setSizePolicy(
+                QSizePolicy.Expanding, QSizePolicy.Expanding
+            )
+            self._stack.addWidget(self._web_view)
+        else:
+            # Placeholder so the stack always has at least one widget
+            self._web_view = None  # type: ignore[assignment]
+
+        self._fallback_label = QLabel("Select a graph on the left.")
+        self._fallback_label.setAlignment(Qt.AlignCenter)
+        self._fallback_label.setWordWrap(True)
+        self._fallback_label.setSizePolicy(
+            QSizePolicy.Expanding, QSizePolicy.Expanding
+        )
+        self._stack.addWidget(self._fallback_label)
+
+        # Start on the web view if available, otherwise the label
+        if _WEBENGINE_AVAILABLE:
+            self._stack.setCurrentWidget(self._web_view)
+        else:
+            self._stack.setCurrentWidget(self._fallback_label)
+
+    @staticmethod
+    def _figure_to_html(fig: go.Figure) -> str:
+        """Convert a Plotly figure to a self-contained HTML string."""
+        return pio.to_html(
+            fig,
+            include_plotlyjs="cdn",   # loads Plotly.js from CDN (~3 MB, cached)
+            full_html=True,
+            config={
+                "scrollZoom": True,       # mouse-wheel zoom
+                "displayModeBar": True,   # show the toolbar (zoom/pan/reset/save)
+                "modeBarButtonsToAdd": [
+                    "drawline",
+                    "drawopenpath",
+                    "eraseshape",
+                ],
+                "toImageButtonOptions": {
+                    "format": "png",
+                    "filename": "zebrafish_graph",
+                    "scale": 2,
+                },
+            },
+        )

--- a/src/ui/main_panels/graph_viewer_widget.py
+++ b/src/ui/main_panels/graph_viewer_widget.py
@@ -562,7 +562,7 @@ class GraphViewerScene(QWidget):
 
                     pio.write_html(
                         src, file=str(html_path),
-                        include_plotlyjs="cdn", auto_open=False
+                        include_plotlyjs=True, auto_open=False
                     )
                     wrote_png = False
                     if _is_kaleido_available():
@@ -1494,7 +1494,7 @@ def save_to_html(fig: go.Figure, title: str, out_dir: Path, config: Dict[str, An
         html_path = out_dir / f"{fname}.html"
         png_path = out_dir / f"{fname}.png"
 
-        pio.write_html(fig, file=str(html_path), include_plotlyjs="cdn", auto_open=False)
+        pio.write_html(fig, file=str(html_path), include_plotlyjs=True, auto_open=False)
 
         try:
             png_bytes = pio.to_image(fig, format="png", scale=2)

--- a/src/ui/main_panels/graph_viewer_widget.py
+++ b/src/ui/main_panels/graph_viewer_widget.py
@@ -34,6 +34,7 @@ from src.core.analysis.cross_correlation import (
 )
 from src.core.graphs.plots.crosscorr_plot import render_crosscorr_plot
 
+from src.ui.components.InteractiveGraph import InteractiveGraph
 from src.session import session
 from src.app_platform.paths import images_dir, sessions_dir
 
@@ -163,7 +164,12 @@ class GraphViewerScene(QWidget):
         self.list.setTextElideMode(Qt.ElideRight)
         self.list.itemSelectionChanged.connect(self._on_selection_changed)
 
-        # Image area for graphs
+        ##CHANGED THIS FOR INTERACTIVE GRAPHS
+        # Interactive graph area (zoom/pan/hover via QWebEngineView)
+        self.interactive_graph = InteractiveGraph()
+        self.interactive_graph.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Expanding)
+
+        # Keep these for fallback PNG path (cross-corr and kaleido-only mode)
         self.image_label = QLabel("Select a graph on the left")
         self.image_label.setObjectName("GraphViewerImageLabel")
         self.image_label.setAlignment(Qt.AlignCenter)
@@ -177,6 +183,8 @@ class GraphViewerScene(QWidget):
         self.scroll.setFrameShape(QFrame.NoFrame)
         self.scroll.setAttribute(Qt.WA_StyledBackground, True)
         self.scroll.setWidget(self.image_label)
+
+        self._original_pixmap = None
 
         # ---------------------------------------------------------------
         # Layout with tabs
@@ -204,8 +212,9 @@ class GraphViewerScene(QWidget):
         left_graph.addWidget(self.csv_nav_row)
         left_graph.addWidget(self.list, stretch=1)
 
+        ##CHANGED HERE FOR INTERACTIVE GRAPH
         right_graph = QVBoxLayout()
-        right_graph.addWidget(self.scroll, stretch=1)
+        right_graph.addWidget(self.interactive_graph, stretch=1)
 
         graph_layout.addLayout(left_graph)
         graph_layout.addLayout(right_graph, stretch=1)
@@ -359,20 +368,7 @@ class GraphViewerScene(QWidget):
         self._context_selected_csv = self._context_csv_id
         self._refresh_context_banner()
 
-        needs_kaleido = any(isinstance(src, go.Figure) for src in self._graphs.values())
-        if needs_kaleido and not self._kaleido_available:
-            self._show_empty_state(
-                "Graphs are available, but cannot be displayed because Kaleido is not installed.\n"
-                "Install it and restart the app:\n"
-                "  pip install --upgrade kaleido\n"
-                "or (conda):\n"
-                "  conda install -c conda-forge python-kaleido"
-            )
-            if isinstance(results_df, pd.DataFrame) and not results_df.empty:
-                self._enable_crosscorr(results_df)
-            else:
-                self._clear_crosscorr_state()
-            return
+        #removed needs_kaleido
 
         if self.list.count() > 0:
             self.list.setEnabled(True)
@@ -827,25 +823,27 @@ class GraphViewerScene(QWidget):
         self._current_name = items[0].text()
         self._show_graph(self._current_name)
 
+    ##CHANGED FOR INTERACTIVE GRAPHS
     def _show_graph(self, name: str):
         source = self._graphs.get(name)
         if source is None:
             self._show_empty_state(f"Missing graph: {name}")
             return
 
-        pix: Optional[QPixmap] = None
         if isinstance(source, go.Figure):
-            pix = self._figure_to_pixmap(source)
-        else:
-            try:
-                pix = QPixmap(str(source))
-            except Exception:
-                pix = None
+            # Use interactive web view (zoom, pan, hover tooltips)
+            self.interactive_graph.set_figure(source)
+            self.list.setEnabled(True)
+            return
+
+        # Fallback: PNG file path saved to disk
+        try:
+            pix = QPixmap(str(source))
+        except Exception:
+            pix = None
 
         if pix is None or pix.isNull():
-            self._show_empty_state(
-                "Unable to render this graph as a static image."
-            )
+            self._show_empty_state("Unable to render this graph as a static image.")
             return
 
         self._original_pixmap = pix
@@ -853,21 +851,32 @@ class GraphViewerScene(QWidget):
         self.image_label.setText("")
         self.list.setEnabled(True)
 
+
     def _set_message(self, text: str):
         self._original_pixmap = None
         self.image_label.setText(text)
         self.image_label.setPixmap(QPixmap())
 
+
+
+
+    #CHANGED FOR INTERACTIVE GRAPHS
     def _show_empty_state(self, text: str = "No graphs available."):
         self._set_message(text)
         self.list.setEnabled(False)
+        self.interactive_graph.clear()
 
+    #CHANGED FOR INTERACTIVE GRAPHS
     def resizeEvent(self, event):
         super().resizeEvent(event)
+        # PNG fallback still needs manual scaling
         if self._original_pixmap:
             self._update_scaled_pixmap()
         if getattr(self, "_current_crosscorr_pixmap", None) is not None:
             self._update_crosscorr_pixmap()
+
+
+
 
     def prepare_for_session_load(self) -> None:
         """Clear viewer UI before attaching a new session (avoids stale list/graphs)."""


### PR DESCRIPTION
## Summary 
What does this change do and why? 
enhances the Graph Viewer by replacing static PNG with an interactive Plotly HTML view using QWebEngineView. 

**Changes:** 
1) 'src/ui/components/InteractiveGraph.py`
- New widget wrapping QWebEngineView to make Plotly figures as interactive HTML. Supports zoom, pan, and point-level hover. Falls back to a label if PyQtWebEngine is not installed. 

2)`src/ui/main_panels/graph_viewer_widget.py`
- Replaced static QLabel/QScrollArea graph display with InteractiveGraph widget. Removed Kaleido dependency for live figure rendering. PNG fallback path is preserved for saved session graphs loaded from disk. 

3) 'src/core/validation/csv_verifier.py` 
- Fixed one-line bug where `expected_full`/`expected_minimal` variables were defined but the check still referenced the old `expected` variable, causing filtered CSVs (x/y only, no likelihood column) to fail validation. 

## Testing 
- [x] Manual UI walkthrough: uploaded correct_format.csv + BaseConfig.json, ran calculation, opened Graph Viewer, clicked graph names --> interactive Plotly chart renders with zoom/pan/hover toolbar 
- [ ] pytest
- [ ] Other 

## Checklist 
- [ ] Docs updated (README/how-to/notes) 
- [ ] Tests added/updated
- [x] No breaking changes: PNG fallback preserved, PyQtWebEngine handled
