### PR TITLE
Bulk UI add

### DIFF
--- a/src/core/calculations/Driver.py
+++ b/src/core/calculations/Driver.py
@@ -1,16 +1,23 @@
 """High-level orchestration for the zebrafish kinematic calculation pipeline."""
 
-from typing import Any, Dict
+from typing import Any, Callable, Dict, Optional
 
 import numpy as np
 import pandas as pd
+
+from .cancelled import CalculationAborted
 from .Metrics import (
     calc_fin_angle, calc_yaw, calc_spine_angles, calc_tail_angle,
     calc_tail_side_and_distance, calc_furthest_tail_point, detect_fin_peaks, get_time_ranges,
 )
 from .custom_angle import build_three_point_angle_column
 
-def run_calculations(parsed_points: Dict[str, Any], config: Dict[str, Any]) -> pd.DataFrame:
+def run_calculations(
+    parsed_points: Dict[str, Any],
+    config: Dict[str, Any],
+    *,
+    cancel_check: Optional[Callable[[], bool]] = None,
+) -> pd.DataFrame:
     """
     Execute the full set of movement calculations on pre-parsed DLC points.
 
@@ -21,6 +28,8 @@ def run_calculations(parsed_points: Dict[str, Any], config: Dict[str, Any]) -> p
     Returns:
         pd.DataFrame: Tabular metrics for each frame, including fin/tail angles, yaw, bout metadata, and peaks.
     """
+    if cancel_check is not None and cancel_check():
+        raise CalculationAborted()
     n_frames = len(parsed_points["spine"][0]["x"]) 
     vp = config["video_parameters"]
     scale_factor = vp["pixel_scale_factor"] * vp["dish_diameter_m"] / vp["pixel_diameter"]
@@ -63,6 +72,8 @@ def run_calculations(parsed_points: Dict[str, Any], config: Dict[str, Any]) -> p
     for start, end in time_ranges:
         bout_yaw_center = head_yaw[start]
         for i in range(start, end + 1):
+            if (i - start) & 0x3FF == 0 and cancel_check is not None and cancel_check():
+                raise CalculationAborted()
             bout_head_yaw[i] = head_yaw[i] - bout_yaw_center
 
     results_dict = {
@@ -83,6 +94,8 @@ def run_calculations(parsed_points: Dict[str, Any], config: Dict[str, Any]) -> p
     }
 
     for seg in range(spine_angles.shape[1]):
+        if (seg & 0x1F) == 0 and cancel_check is not None and cancel_check():
+            raise CalculationAborted()
         results_dict[f"TailAngle_{seg}"] = spine_angles[:, seg]
 
     # Optional custom calculation: directed three-point angle
@@ -92,6 +105,8 @@ def run_calculations(parsed_points: Dict[str, Any], config: Dict[str, Any]) -> p
         results_dict[output_col] = ang
         print(log_msg)
 
+    if cancel_check is not None and cancel_check():
+        raise CalculationAborted()
     result_df = pd.DataFrame(results_dict)
 
     # Build new time range columns in one go

--- a/src/core/calculations/cancelled.py
+++ b/src/core/calculations/cancelled.py
@@ -1,0 +1,7 @@
+"""User-initiated cancellation of long calculation work (cooperative, checked on the run path)."""
+
+
+class CalculationAborted(Exception):
+    """Raised when the user stops a calculation before it completes."""
+
+    pass

--- a/src/core/validation/json_verifier.py
+++ b/src/core/validation/json_verifier.py
@@ -79,6 +79,22 @@ def extra_checks(config: dict):
                         errors.append(
                             f"{part_key}[{idx}] must be a string, got {type(v).__name__}")
 
+    # Backlog #2: unique names and no spine/tail overlap
+    sp = points.get("spine")
+    ta = points.get("tail")
+    if isinstance(sp, list) and sp and all(isinstance(x, str) for x in sp):
+        if len(sp) != len(set(sp)):
+            errors.append("spine must not contain duplicate point names")
+    if isinstance(ta, list) and ta and all(isinstance(x, str) for x in ta):
+        if len(ta) != len(set(ta)):
+            errors.append("tail must not contain duplicate point names")
+    if isinstance(sp, list) and isinstance(ta, list):
+        ov = set(sp) & set(ta)
+        if ov:
+            errors.append(
+                f"spine and tail must not share the same point names: {sorted(ov)}"
+            )
+
     # head must contain pt1 and pt2 as single string points
     head = points.get("head", {})
     if not isinstance(head, dict):

--- a/src/session/session.py
+++ b/src/session/session.py
@@ -1,11 +1,12 @@
 from os import path
 import json
+import shutil
 from pathlib import Path
 
 from PyQt5.QtCore import pyqtSignal, QObject
 from PyQt5.QtWidgets import QMessageBox
 
-from app_platform.paths import SESSION_JSON_FILENAME, session_bundle_dir
+from app_platform.paths import SESSION_JSON_FILENAME, session_bundle_dir, sessions_dir
 
 class Session(QObject):
     session_updated = pyqtSignal()
@@ -27,17 +28,82 @@ class Session(QObject):
         # Persisted “last used” calculation inputs (so we can rebuild graphs on reopen).
         self.last_csv_path = None
         self.last_config_path = None
-    
-    def addCSV(self, csv_path):
+        # user-picked path -> canonical key under sessions/.../uploads (backlog #3)
+        self._import_alias_by_user: dict[str, str] = {}
+
+    def _resolve_csv_key(self, csv_path: str) -> str:
+        if not csv_path:
+            return csv_path
+        if csv_path in self.csvs:
+            return csv_path
+        return self._import_alias_by_user.get(csv_path, csv_path)
+
+    def _canonical_single_csv_path(self, csv_path: str) -> str:
+        """
+        Backlog #3: keep a copy under sessions/<name>/uploads/ so the session
+        can reopen even if the user moves or renames the original file.
+        """
+        if not path.exists(csv_path) or not path.isfile(csv_path):
+            return path.normpath(path.abspath(str(csv_path)))
+        src = Path(csv_path).resolve()
+        up = (Path(sessions_dir()) / self.getName() / "uploads").resolve()
+        try:
+            up.mkdir(parents=True, exist_ok=True)
+        except OSError:
+            return str(src)
+        try:
+            src.relative_to(up)
+            return str(src)
+        except ValueError:
+            pass
+        # Idempotent: second call with same file path reuses the existing session key
+        quick = (up / src.name).resolve()
+        if quick.exists() and str(quick) in self.csvs:
+            return str(quick)
+        dest = (up / src.name).resolve()
+        if dest == src:
+            return str(src)
+        if dest.exists():
+            stem, suf = src.stem, src.suffix
+            n = 1
+            while True:
+                alt = (up / f"{stem}_import{n}{suf}").resolve()
+                if not alt.exists():
+                    dest = alt
+                    break
+                n += 1
+        try:
+            shutil.copy2(str(src), str(dest))
+        except OSError as e:
+            print(f"[Session] Could not copy CSV into session: {e}")
+            return str(src)
+        return str(dest)
+
+    def addCSV(self, csv_path, *, session_import: bool = True):
+        """
+        Register a single-CSV input. When ``session_import`` is True (default), copy
+        the file into ``sessions/<name>/uploads/`` (backlog #3) so paths stay valid
+        if the user moves the original. When False (e.g. ``load_session_from_json``),
+        use the path string as stored in the JSON without copying.
+        """
         if not path.exists(csv_path):
             print(f"[Session] CSV path does not exist: {csv_path}")
             return
 
+        if session_import:
+            orig = path.normpath(path.abspath(str(csv_path)))
+            key = self._canonical_single_csv_path(csv_path)
+        else:
+            key = path.normpath(path.abspath(str(csv_path)))
+            orig = key
+
         # Idempotent: never overwrite an existing CSV entry, because that would
         # wipe any configs/graphs already attached to it (losing progress).
-        if csv_path not in self.csvs:
-            self.csvs[csv_path] = {}
-            self.session_updated.emit()
+        if key not in self.csvs:
+            self.csvs[key] = {}
+        if session_import and orig != key and orig not in self._import_alias_by_user:
+            self._import_alias_by_user[orig] = key
+        self.session_updated.emit()
 
     def addCSVFolder(self, folder_path: str, csv_files: list[str]):
         """Register a folder of CSVs as a single CSV input ID."""
@@ -81,6 +147,7 @@ class Session(QObject):
             print(f"[Session] Config path does not exist: {config_path}")
             return
 
+        csv_path = self._resolve_csv_key(csv_path)
         # Be permissive: ensure the CSV node exists, then attach config.
         if csv_path not in self.csvs:
             self.csvs[csv_path] = {}
@@ -103,7 +170,7 @@ class Session(QObject):
                     self.session_updated.emit()
 
     def getConfigsForCSV(self, csv_path):
-        return self.csvs.get(csv_path, {})
+        return self.csvs.get(self._resolve_csv_key(csv_path), {})
 
     def getAllCSVs(self):
         return list(self.csvs.keys())
@@ -191,6 +258,7 @@ class Session(QObject):
             "calculation_has_run": bool(getattr(self, "calculation_has_run", False)),
             "last_csv_path": getattr(self, "last_csv_path", None),
             "last_config_path": getattr(self, "last_config_path", None),
+            "csv_import_alias": dict(self._import_alias_by_user or {}),
         }
     
     def length(self):
@@ -211,10 +279,13 @@ class Session(QObject):
             json.dump(self.toDict(), f, indent=4)
 
     def checkExists(self, csv_path=None, config_path=None):
+        ck = self._resolve_csv_key(csv_path) if csv_path else None
         if csv_path in self.csvs and config_path is None:
             return True
+        if ck and ck in self.csvs and config_path is None:
+            return True
         if csv_path and config_path:
-            return config_path in self.csvs.get(csv_path, {})
+            return config_path in self.csvs.get(ck, {})
 
         return config_path in self.getAllConfigs()
 
@@ -222,6 +293,7 @@ class Session(QObject):
         """Detach one JSON config (and its graph paths) from a CSV row; prune folder_graphs."""
         if not csv_path or not config_path:
             return
+        csv_path = self._resolve_csv_key(csv_path)
         row = self.csvs.get(csv_path)
         if not row or config_path not in row:
             return
@@ -274,12 +346,13 @@ def load_session_from_json(json_path):
     session.calculation_has_run = bool(data.get("calculation_has_run", False))
     session.last_csv_path = data.get("last_csv_path")
     session.last_config_path = data.get("last_config_path")
+    session._import_alias_by_user = data.get("csv_import_alias") or {}
     session.csv_folders = data.get("csv_folders") or {}
     session.folder_graphs = data.get("folder_graphs") or {}
 
     csvs = data.get("csvs", {})
     for csv_path, configs in csvs.items():
-        session.addCSV(csv_path)
+        session.addCSV(csv_path, session_import=False)
         for config_path, graphs in configs.items():
             session.addConfigToCSV(csv_path, config_path)
             for graph_path in graphs:

--- a/src/ui/components/bodypart_pool_list.py
+++ b/src/ui/components/bodypart_pool_list.py
@@ -1,0 +1,302 @@
+"""
+Bodypart chip pools for Generate Config: two palette lists and two ordered spine/tail lists.
+
+* **Add (palette):** `set_add_callback` — `config_generator` calls `add_name` then refills the Available pool.
+* **Spine / tail:** Drag to reorder. Drag a block onto the paired **Available** list to return it, or
+  **click without dragging** on a block to return it. Names appear in Available *or* Spine/Tail, not both
+  (see `_refill_available_pools` in `config_generator_widget`).
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from PyQt5.QtCore import QRect, QTimer, Qt
+from PyQt5.QtGui import QCursor, QFont, QFontMetrics
+from PyQt5.QtWidgets import QApplication, QListView, QListWidget, QListWidgetItem, QToolTip, QWidget
+
+BP_MIME = "application/x-cv-zebrafish-bp"
+
+
+class ChipDelegate:
+    """Long-label tooltips when the label is wider than the list viewport."""
+
+    def __init__(self, list_widget: QListWidget) -> None:
+        self.lw = list_widget
+        self.lw.setMouseTracking(True)
+        self.lw.itemEntered.connect(self._on_item_entered)
+
+    def _on_item_entered(self, item: QListWidgetItem) -> None:
+        t = (item.text() or "").strip()
+        if not t:
+            return
+        fm = self.lw.fontMetrics()
+        cell_w = max(1, self.lw.width() - 32)
+        if fm.horizontalAdvance(t) > cell_w:
+            QToolTip.showText(QCursor.pos(), t, self.lw, QRect(), 6000)
+        else:
+            QToolTip.hideText()
+
+
+def _refit_list_height(lw: QListWidget) -> None:
+    n = max(0, lw.count())
+    fm = lw.fontMetrics()
+    row_h = max(32, fm.height() + 12)
+    max_rows = 10
+    if n == 0:
+        h = 64
+    else:
+        h = min(n, max_rows) * row_h + 16
+    lw.setMinimumHeight(h)
+    lw.setMaximumHeight(1_000_000)
+
+
+class BodypartSequenceList(QListWidget):
+    """Ordered spine or tail; internal drag to reorder; drop from palette; drag to palette removes."""
+
+    def __init__(self, parent: QWidget | None = None) -> None:
+        super().__init__(parent)
+        self.setObjectName("BodypartPoolSequence")
+        self.setSelectionMode(QListWidget.SingleSelection)
+        self.setViewMode(QListView.ListMode)
+        self.setFlow(QListView.TopToBottom)
+        self.setWrapping(False)
+        self.setResizeMode(QListView.Fixed)
+        self.setSpacing(4)
+        self.setFocusPolicy(Qt.StrongFocus)
+        self.setDragEnabled(True)
+        self.setAcceptDrops(True)
+        self.setDropIndicatorShown(True)
+        self.setDefaultDropAction(Qt.MoveAction)
+        self.setDragDropMode(QListWidget.DragDrop)
+        self.setHorizontalScrollBarPolicy(Qt.ScrollBarAlwaysOff)
+        self.setVerticalScrollBarPolicy(Qt.ScrollBarAsNeeded)
+        self.setTextElideMode(Qt.ElideNone)
+        self.setMinimumHeight(64)
+        self.setUniformItemSizes(False)
+        self.setCursor(Qt.OpenHandCursor)
+        self._palette: BodypartPaletteList | None = None
+        self._dnd_from_row: int = -1
+        self._chip_delegate: ChipDelegate | None = None
+        self._return_callback: Callable[[str], None] | None = None
+        self._press_item: QListWidgetItem | None = None
+        self._click_origin = None
+        self._did_real_drag: bool = False
+        m = self.model()
+        m.rowsInserted.connect(self._on_rows_change)
+        m.rowsRemoved.connect(self._on_rows_change)
+        m.modelReset.connect(self._on_rows_change)
+
+    def set_palette(self, pal: "BodypartPaletteList") -> None:
+        self._palette = pal
+
+    def set_chip_delegate(self, d: ChipDelegate) -> None:
+        self._chip_delegate = d
+
+    def set_return_callback(self, fn: Callable[[str], None] | None) -> None:
+        """On a short left click (no drag) on a row, the row is removed and fn(name) is called (e.g. to refill Available)."""
+        self._return_callback = fn
+
+    def _on_rows_change(self, *_a) -> None:
+        _refit_list_height(self)
+
+    def _names(self) -> set[str]:
+        return {(self.item(i).text() or "").strip() for i in range(self.count()) if self.item(i)}
+
+    def has_name(self, name: str) -> bool:
+        n = (name or "").strip()
+        return n in self._names()
+
+    def add_name(self, name: str) -> bool:
+        n = (name or "").strip()
+        if not n or self.has_name(n):
+            return False
+        it = QListWidgetItem(n)
+        it.setData(Qt.UserRole, n)
+        self.addItem(it)
+        _refit_list_height(self)
+        return True
+
+    def startDrag(self, supportedActions) -> None:  # noqa: N802
+        self._did_real_drag = True
+        self._dnd_from_row = self.currentRow()
+        super().startDrag(supportedActions)
+        self._dnd_from_row = -1
+
+    def dragEnterEvent(self, event) -> None:  # noqa: N802
+        m = event.mimeData()
+        if m and m.hasFormat(BP_MIME) and self._palette and event.source() is self._palette:
+            event.setDropAction(Qt.CopyAction)
+            event.acceptProposedAction()
+            return
+        super().dragEnterEvent(event)
+
+    def dragMoveEvent(self, event) -> None:  # noqa: N802
+        m = event.mimeData()
+        if m and m.hasFormat(BP_MIME) and self._palette and event.source() is self._palette:
+            event.setDropAction(Qt.CopyAction)
+            event.acceptProposedAction()
+            return
+        super().dragMoveEvent(event)
+
+    def dropEvent(self, event) -> None:  # noqa: N802
+        md = event.mimeData()
+        if md is not None and md.hasFormat(BP_MIME) and self._palette and event.source() is self._palette:
+            t = str(bytes(md.data(BP_MIME)).decode("utf-8", errors="replace")).strip()
+            if t:
+                self.add_name(t)
+            event.setDropAction(Qt.CopyAction)
+            event.accept()
+            _refit_list_height(self)
+            return
+        super().dropEvent(event)
+        _refit_list_height(self)
+
+    def mousePressEvent(self, e) -> None:  # noqa: N802
+        if e.button() == Qt.LeftButton:
+            self._did_real_drag = False
+            self._click_origin = e.pos()
+            self._press_item = self.itemAt(e.pos())
+        it = self._press_item
+        if it is not None:
+            self.setCurrentItem(it)
+        super().mousePressEvent(e)
+
+    def mouseReleaseEvent(self, e) -> None:  # noqa: N802
+        super().mouseReleaseEvent(e)
+        if (
+            e.button() == Qt.LeftButton
+            and self._return_callback
+            and self._press_item is not None
+            and self._click_origin is not None
+            and not self._did_real_drag
+        ):
+            if (e.pos() - self._click_origin).manhattanLength() > QApplication.startDragDistance():
+                pass
+            else:
+                it = self.itemAt(e.pos())
+                if it is self._press_item:
+                    n = (it.text() or "").strip()
+                    row = self.row(it)
+                    if n and row >= 0:
+                        self.takeItem(row)
+                        self._return_callback(n)
+                    _refit_list_height(self)
+        self._press_item = None
+        self._did_real_drag = False
+
+    def resizeEvent(self, e) -> None:  # noqa: N802
+        super().resizeEvent(e)
+        _refit_list_height(self)
+
+    def showEvent(self, e) -> None:  # noqa: N802
+        super().showEvent(e)
+        QTimer.singleShot(0, lambda: _refit_list_height(self))
+
+    def mouseMoveEvent(self, e) -> None:  # noqa: N802
+        it = self.itemAt(e.pos())
+        if it is not None:
+            self.setCursor(Qt.PointingHandCursor)
+        else:
+            self.setCursor(Qt.OpenHandCursor)
+        super().mouseMoveEvent(e)
+
+
+class BodypartPaletteList(QListWidget):
+    """
+    All bodypart names. Click a row to add to the active spine or tail (see set_add_callback).
+    Dragging *from* this list is off; you may drop spine/tail items here to remove them.
+    """
+
+    def __init__(self, parent: QWidget | None = None) -> None:
+        super().__init__(parent)
+        self.setObjectName("BodypartPoolPalette")
+        self.setSelectionMode(QListWidget.SingleSelection)
+        self.setViewMode(QListView.ListMode)
+        self.setFlow(QListView.TopToBottom)
+        self.setWrapping(False)
+        self.setResizeMode(QListView.Fixed)
+        self.setSpacing(4)
+        self.setFocusPolicy(Qt.StrongFocus)
+        self.setDragEnabled(False)
+        self.setDragDropMode(QListWidget.DropOnly)
+        self.setAcceptDrops(True)
+        self.setDropIndicatorShown(True)
+        self.setDefaultDropAction(Qt.CopyAction)
+        self.setHorizontalScrollBarPolicy(Qt.ScrollBarAlwaysOff)
+        self.setVerticalScrollBarPolicy(Qt.ScrollBarAsNeeded)
+        self.setTextElideMode(Qt.ElideNone)
+        self.setMinimumHeight(64)
+        self.setUniformItemSizes(False)
+        self.setCursor(Qt.PointingHandCursor)
+        self._add_callback: Callable[[str], None] | None = None
+        self._chip_delegate: ChipDelegate | None = None
+        self._after_sequence_drop: Callable[[], None] | None = None
+        m = self.model()
+        m.rowsInserted.connect(self._on_rows_change)
+        m.rowsRemoved.connect(self._on_rows_change)
+        m.modelReset.connect(self._on_rows_change)
+
+    def set_chip_delegate(self, d: ChipDelegate) -> None:
+        self._chip_delegate = d
+
+    def set_after_sequence_drop(self, fn: Callable[[], None] | None) -> None:
+        self._after_sequence_drop = fn
+
+    def set_add_callback(self, fn: Callable[[str], None] | None) -> None:
+        self._add_callback = fn
+
+    def _on_rows_change(self, *_a) -> None:
+        _refit_list_height(self)
+
+    def mousePressEvent(self, e) -> None:  # noqa: N802
+        it = self.itemAt(e.pos())
+        if e.button() == Qt.LeftButton and it is not None and self._add_callback:
+            t = (it.text() or "").strip()
+            if t:
+                self._add_callback(t)
+        if it is not None:
+            self.setCurrentItem(it)
+        super().mousePressEvent(e)
+
+    def dragEnterEvent(self, event) -> None:  # noqa: N802
+        if isinstance(event.source(), BodypartSequenceList):
+            event.setDropAction(Qt.MoveAction)
+            event.acceptProposedAction()
+            return
+        super().dragEnterEvent(event)
+
+    def dragMoveEvent(self, event) -> None:  # noqa: N802
+        if isinstance(event.source(), BodypartSequenceList):
+            event.setDropAction(Qt.MoveAction)
+            event.acceptProposedAction()
+            return
+        super().dragMoveEvent(event)
+
+    def dropEvent(self, event) -> None:  # noqa: N802
+        src = event.source()
+        if isinstance(src, BodypartSequenceList):
+            r = int(getattr(src, "_dnd_from_row", -1))
+            if 0 <= r < src.count():
+                src.takeItem(r)
+            if self._after_sequence_drop:
+                self._after_sequence_drop()
+            event.acceptProposedAction()
+            return
+        super().dropEvent(event)
+        _refit_list_height(self)
+
+    def resizeEvent(self, e) -> None:  # noqa: N802
+        super().resizeEvent(e)
+        _refit_list_height(self)
+
+    def showEvent(self, e) -> None:  # noqa: N802
+        super().showEvent(e)
+        QTimer.singleShot(0, lambda: _refit_list_height(self))
+
+    def mouseMoveEvent(self, e) -> None:  # noqa: N802
+        it = self.itemAt(e.pos())
+        if it is not None:
+            self.setCursor(Qt.PointingHandCursor)
+        else:
+            self.setCursor(Qt.OpenHandCursor)
+        super().mouseMoveEvent(e)

--- a/src/ui/components/console_dialog.py
+++ b/src/ui/components/console_dialog.py
@@ -46,7 +46,19 @@ class ConsoleViewerDialog(QDialog):
         outer = QVBoxLayout(self)
         outer.setContentsMargins(0, 0, 0, 0)
         outer.setSpacing(0)
-        outer.addWidget(DialogTitleBar(self, "Console", self))
+        outer.addWidget(
+            DialogTitleBar(
+                self,
+                "Console",
+                self,
+                help_title="Console",
+                help_paragraph=(
+                    "Open this from the Help menu when you need to read recent log text and in-app toasts. "
+                    "Click Refresh to load the latest buffer, select text in the box, and use Ctrl+C (or your usual copy command) to paste it elsewhere. "
+                    "Click Close when you are done. Most runs do not need this — it is for debugging when something looks wrong."
+                ),
+            )
+        )
         outer.addWidget(horizontal_separator())
 
         body = QWidget()

--- a/src/ui/components/dialog_title_bar.py
+++ b/src/ui/components/dialog_title_bar.py
@@ -2,12 +2,26 @@
 
 from __future__ import annotations
 
+from typing import Optional, Sequence
+
 from PyQt5.QtCore import QPoint, Qt
 from PyQt5.QtWidgets import QDialog, QHBoxLayout, QLabel, QToolButton, QWidget
 
+from ui.components.scene_help import create_scene_help_button
+
 
 class DialogTitleBar(QWidget):
-    def __init__(self, dialog: QDialog, title: str, parent: QWidget | None = None):
+    def __init__(
+        self,
+        dialog: QDialog,
+        title: str,
+        parent: QWidget | None = None,
+        *,
+        help_title: Optional[str] = None,
+        help_paragraph: Optional[str] = None,
+        help_tips: Optional[Sequence[str]] = None,
+    ):
+        # help_title is the window name for the help dialog only; the modal title is f"Help - {help_title}".
         super().__init__(parent)
         self.setObjectName("AppTitleBar")
         self.setAttribute(Qt.WA_StyledBackground, True)
@@ -23,6 +37,15 @@ class DialogTitleBar(QWidget):
         layout.addWidget(self._title, 0, Qt.AlignVCenter)
 
         layout.addStretch(1)
+
+        if help_title and help_paragraph:
+            hb = create_scene_help_button(
+                self,
+                title=help_title,
+                paragraph=help_paragraph,
+                tips=tuple(help_tips) if help_tips is not None else None,
+            )
+            layout.addWidget(hb, 0, Qt.AlignVCenter)
 
         self._btn_close = QToolButton()
         self._btn_close.setObjectName("TitleChromeClose")

--- a/src/ui/components/scene_help.py
+++ b/src/ui/components/scene_help.py
@@ -1,0 +1,49 @@
+"""Reusable scene help: small ⓘ control opens a short modal (spec #94)."""
+
+from __future__ import annotations
+
+from typing import Optional, Sequence
+
+from PyQt5.QtCore import Qt
+from PyQt5.QtWidgets import QToolButton, QWidget
+
+
+def format_help_body(paragraph: str, tips: Optional[Sequence[str]] = None) -> str:
+    t = (paragraph or "").strip()
+    if tips:
+        t += "\n\nTips:\n" + "\n".join(f"• {s}" for s in tips)
+    return t
+
+
+def show_scene_help(
+    parent: QWidget,
+    window_name: str,
+    paragraph: str,
+    tips: Optional[Sequence[str]] = None,
+) -> None:
+    """Frameless, themed window titled ``Help - {window_name}`` (no OS title bar, no system info icon)."""
+    from ui.components.scene_help_dialog import SceneHelpDialog
+
+    SceneHelpDialog(parent, window_name, paragraph, tips).exec_()
+
+
+def create_scene_help_button(
+    parent: QWidget,
+    *,
+    title: str,
+    paragraph: str,
+    tips: Optional[Sequence[str]] = None,
+) -> QToolButton:
+    """ⓘ in the title area; click opens a themed help dialog: title bar shows ``Help - {title}`` (``title`` = window name, e.g. ``No Session Window``)."""
+    btn = QToolButton(parent)
+    btn.setObjectName("SceneHelpButton")
+    btn.setText("ⓘ")
+    btn.setToolTip("Help for this screen")
+    btn.setAutoRaise(True)
+    btn.setCursor(Qt.PointingHandCursor)
+
+    def _on() -> None:
+        show_scene_help(parent, title, paragraph, tips)
+
+    btn.clicked.connect(_on)
+    return btn

--- a/src/ui/components/scene_help_dialog.py
+++ b/src/ui/components/scene_help_dialog.py
@@ -1,0 +1,96 @@
+"""Themed, frameless help window for scene ⓘ (replaces native QMessageBox so title bar matches dark mode)."""
+
+from __future__ import annotations
+
+from typing import Optional, Sequence
+
+from PyQt5.QtCore import Qt
+from PyQt5.QtGui import QFont
+from PyQt5.QtWidgets import QDialog, QFrame, QPlainTextEdit, QVBoxLayout, QWidget
+
+from styles.themes import THEMES, apply_theme
+
+from ui.components.chrome_separators import horizontal_separator
+from ui.components.dialog_title_bar import DialogTitleBar
+from ui.components.scene_help import format_help_body
+
+
+def _transient_for_help(start: Optional[QWidget]) -> Optional[QWidget]:
+    """Use the nearest parent QDialog (or the shell) so the help window centers and stacks well."""
+    w = start
+    while w is not None:
+        if isinstance(w, QDialog):
+            return w
+        w = w.parentWidget()
+    return start
+
+
+def _theme_name_from_context(start: Optional[QWidget]) -> str:
+    w = start
+    while w is not None:
+        if hasattr(w, "current_theme"):
+            return getattr(w, "current_theme", "dark") or "dark"
+        w = w.parentWidget()
+    return "dark"
+
+
+def _frame_title(window_name: str) -> str:
+    wn = (window_name or "").strip()
+    if wn.lower().startswith("help - "):
+        return wn
+    return f"Help - {wn}"
+
+
+class SceneHelpDialog(QDialog):
+    """
+    No OS chrome, no information pixmap — title uses DialogTitleBar (same as other app dialogs).
+    Title: ``Help - {window_name}`` (e.g. ``Help - No Session Window``).
+    """
+
+    def __init__(
+        self,
+        requester: Optional[QWidget],
+        window_name: str,
+        paragraph: str,
+        tips: Optional[Sequence[str]] = None,
+    ):
+        tr = _transient_for_help(requester) or requester
+        super().__init__(tr)
+        self.setObjectName("SceneHelpDialog")
+        self.setWindowFlags(Qt.Dialog | Qt.FramelessWindowHint)
+        self.setAttribute(Qt.WA_StyledBackground, True)
+        self.setModal(True)
+        self.setWindowModality(Qt.WindowModal)
+
+        theme_name = _theme_name_from_context(requester)
+        apply_theme(self, THEMES[theme_name])
+        title_text = _frame_title(window_name)
+        self.setWindowTitle(title_text)
+
+        outer = QVBoxLayout(self)
+        outer.setContentsMargins(0, 0, 0, 0)
+        outer.setSpacing(0)
+        outer.addWidget(DialogTitleBar(self, title_text, self))
+        outer.addWidget(horizontal_separator())
+
+        body_wrap = QWidget()
+        body_wrap.setObjectName("SceneHelpDialogBody")
+        body_wrap.setAttribute(Qt.WA_StyledBackground, True)
+        bl = QVBoxLayout(body_wrap)
+        bl.setContentsMargins(16, 12, 16, 16)
+        bl.setSpacing(0)
+
+        text = QPlainTextEdit()
+        text.setObjectName("SceneHelpDialogText")
+        text.setReadOnly(True)
+        text.setFrameShape(QFrame.NoFrame)
+        text.setPlainText(format_help_body(paragraph, tips))
+        text.setLineWrapMode(QPlainTextEdit.WidgetWidth)
+        f = QFont()
+        f.setPointSize(10)
+        text.setFont(f)
+        bl.addWidget(text, 1)
+        outer.addWidget(body_wrap, stretch=1)
+
+        self.setMinimumSize(400, 220)
+        self.resize(500, 320)

--- a/src/ui/main_panels/empty_session_panel.py
+++ b/src/ui/main_panels/empty_session_panel.py
@@ -1,8 +1,9 @@
 from PyQt5.QtCore import Qt, pyqtSignal
 from PyQt5.QtGui import QFont
-from PyQt5.QtWidgets import QLabel, QVBoxLayout, QWidget
+from PyQt5.QtWidgets import QHBoxLayout, QLabel, QVBoxLayout, QWidget
 
 from ui.components.branding import fish_pixmap
+from ui.components.scene_help import create_scene_help_button
 
 
 class EmptySessionPanel(QWidget):
@@ -18,6 +19,27 @@ class EmptySessionPanel(QWidget):
         layout.setAlignment(Qt.AlignCenter)
         layout.setContentsMargins(40, 30, 40, 30)
         layout.setSpacing(20)
+
+        top = QHBoxLayout()
+        top.setContentsMargins(0, 0, 0, 0)
+        top.addStretch(1)
+        top.addWidget(
+            create_scene_help_button(
+                self,
+                title="No Session Window",
+                paragraph=(
+                    "To create a session: click anywhere on this screen to open Session Select, or use the File menu and choose Session Select…. "
+                    "There you can click + Create New or Upload New to add a new session file, or click a row in the list to open a session you already have. "
+                    "After you have a session, add your data and work from the other screens."
+                ),
+                tips=(
+                    "To repoint a missing file, open Session Select, right-click the row, and choose Find location…",
+                ),
+            ),
+            0,
+            Qt.AlignRight | Qt.AlignTop,
+        )
+        layout.addLayout(top)
 
         layout.addStretch(2)
 

--- a/src/ui/main_panels/graph_viewer_widget.py
+++ b/src/ui/main_panels/graph_viewer_widget.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Callable, Dict, List, Optional, Tuple
 
 import re
 import numpy as np
@@ -8,6 +8,7 @@ from pathlib import Path
 from PyQt5.QtCore import Qt, QSize
 from PyQt5.QtGui import QIcon, QPixmap
 from PyQt5.QtWidgets import (
+    QApplication,
     QComboBox,
     QFrame,
     QHBoxLayout,
@@ -34,12 +35,31 @@ from src.core.analysis.cross_correlation import (
 )
 from src.core.graphs.plots.crosscorr_plot import render_crosscorr_plot
 
+from ui.components.scene_help import create_scene_help_button
+
+from src.core.calculations.cancelled import CalculationAborted
 from src.session import session
 from src.app_platform.paths import images_dir, sessions_dir
 
 FOLDER_ICON = images_dir() / "folder-black.svg"
 
 GraphSource = Any  # go.Figure or a saved image path (str/Path)
+
+
+def count_figures_in_graph_dict(graphs: Optional[Dict[str, Any]]) -> int:
+    """How many `go.Figure` entries (each will be written to session disk when saving)."""
+    if not graphs:
+        return 0
+    return sum(1 for s in graphs.values() if isinstance(s, go.Figure))
+
+
+def count_figures_in_folder_runs(
+    graphs_by_csv: Optional[Dict[str, Dict[str, Any]]],
+) -> int:
+    """Total Plotly figures across a folder (multi-CSV) result."""
+    if not graphs_by_csv:
+        return 0
+    return sum(count_figures_in_graph_dict(d) for d in graphs_by_csv.values())
 
 DOT_PLOT_SPECS: Tuple[Dict[str, Any], ...] = (
     {
@@ -91,10 +111,15 @@ DOT_PLOT_SPECS: Tuple[Dict[str, Any], ...] = (
 
 class GraphViewerScene(QWidget):
     """
-    Graph viewer with two tabs:
-      1. Graphs - standard plots (dot, fin/tail, spine, head)
-      2. Cross-Correlation - signal pair analysis
+    Graph viewer with three tabs:
+      1. Graphs — standard plots (dot, fin/tail, spine, head)
+      2. Cross-Correlation — signal pair analysis
+      3. Compare — two standard graphs side by side (any CSVs / any graph names)
     """
+
+    TAB_GRAPHS = 0
+    TAB_CROSS = 1
+    TAB_COMPARE = 2
 
     def __init__(self):
         super().__init__()
@@ -120,6 +145,8 @@ class GraphViewerScene(QWidget):
         self._crosscorr_signals = []
         self._current_crosscorr_fig = None
         self._current_df = None
+        # Last single-CSV run metrics (for re-open Cross-Correlation tab; backlog #1)
+        self._last_single_run_df: Optional[pd.DataFrame] = None
 
         # Context banner
         self.context_icon = QLabel()
@@ -158,7 +185,7 @@ class GraphViewerScene(QWidget):
 
         self.list = QListWidget()
         self.list.setObjectName("GraphViewerGraphList")
-        self.list.setMinimumWidth(240)
+        self.list.setMinimumWidth(180)
         self.list.setHorizontalScrollBarPolicy(Qt.ScrollBarAlwaysOff)
         self.list.setTextElideMode(Qt.ElideRight)
         self.list.itemSelectionChanged.connect(self._on_selection_changed)
@@ -184,8 +211,22 @@ class GraphViewerScene(QWidget):
         context_row = QHBoxLayout()
         context_row.setContentsMargins(0, 0, 0, 0)
         context_row.setSpacing(8)
-        context_row.addWidget(self.context_icon, 0, Qt.AlignLeft)
-        context_row.addWidget(self.context_text, 1)
+        context_row.addWidget(self.context_icon, 0, Qt.AlignLeft | Qt.AlignTop)
+        context_row.addWidget(self.context_text, 1, Qt.AlignTop)
+        self._help_btn = create_scene_help_button(
+            self,
+            title="Graph Viewer",
+            paragraph=(
+                "On the Graphs tab, click a name in the list on the left to show that plot on the right. "
+                "If the session has a folder of CSVs, use the drop-down and Prev/Next to choose which file you are viewing. "
+                "Open the Compare tab to place two standard graphs side by side — pick dataset(s) and a graph for each side (same or different files). "
+                "Open Cross-Correlation when you need that analysis — it is a different tool than Compare."
+            ),
+            tips=(
+                "In Select & Run, when a CSV has more than one config, the small tree icon can open View Output for a specific pair.",
+            ),
+        )
+        context_row.addWidget(self._help_btn, 0, Qt.AlignRight | Qt.AlignTop)
 
         context_widget = QWidget()
         context_widget.setObjectName("GraphViewerContextBar")
@@ -259,19 +300,292 @@ class GraphViewerScene(QWidget):
         crosscorr_layout.addWidget(self.crosscorr_scroll, stretch=1)
 
         self.tab_widget.addTab(crosscorr_tab, "Cross-Correlation")
-        self.tab_widget.setTabEnabled(1, False)  # disabled until data loads
+        self.tab_widget.setTabEnabled(self.TAB_CROSS, False)  # disabled until data loads
 
-        # Main layout
+        self._init_compare_tab()
+        self.tab_widget.addTab(self._compare_tab_root, "Compare")
+        self.tab_widget.setTabEnabled(self.TAB_COMPARE, False)
+        self.tab_widget.currentChanged.connect(self._on_main_tab_changed)
+
+        # Main layout — panel margins match other workspace scenes so ⓘ stays in the same top-right relationship.
         right = QVBoxLayout()
+        right.setContentsMargins(0, 0, 0, 0)
+        right.setSpacing(8)
         right.addWidget(context_widget)
         right.addWidget(self.tab_widget, stretch=1)
 
         outer = QVBoxLayout()
+        outer.setContentsMargins(40, 30, 40, 30)
+        outer.setSpacing(0)
         outer.addLayout(right, stretch=1)
         self.setLayout(outer)
 
         self._show_empty_state("No graphs available.")
         self._refresh_context_banner()
+
+    def _init_compare_tab(self) -> None:
+        self._compare_tab_root = QWidget()
+        self._compare_tab_root.setObjectName("GraphViewerCompareTab")
+        compare_outer = QHBoxLayout(self._compare_tab_root)
+        compare_outer.setContentsMargins(0, 0, 0, 0)
+        compare_outer.setSpacing(8)
+
+        self._compare_left_scroll = QScrollArea()
+        self._compare_left_scroll.setObjectName("GraphViewerCompareLeftScroll")
+        self._compare_left_scroll.setWidgetResizable(True)
+        self._compare_left_scroll.setHorizontalScrollBarPolicy(Qt.ScrollBarAlwaysOff)
+        self._compare_left_scroll.setMaximumWidth(320)
+        self._compare_left_inner = QWidget()
+        cl = QVBoxLayout(self._compare_left_inner)
+        cl.setSpacing(12)
+        cl.addWidget(QLabel("<b>Graph A</b>"))
+        self.compare_csv_a = QComboBox()
+        self.compare_csv_a.setObjectName("GraphViewerCompareCsvA")
+        self.compare_csv_a.currentIndexChanged.connect(self._on_compare_inputs_changed)
+        cl.addWidget(self.compare_csv_a)
+        self.compare_graph_a = QComboBox()
+        self.compare_graph_a.setObjectName("GraphViewerCompareGraphA")
+        self.compare_graph_a.currentIndexChanged.connect(self._on_compare_inputs_changed)
+        cl.addWidget(self.compare_graph_a)
+        cl.addSpacing(8)
+        cl.addWidget(QLabel("<b>Graph B</b>"))
+        self.compare_csv_b = QComboBox()
+        self.compare_csv_b.setObjectName("GraphViewerCompareCsvB")
+        self.compare_csv_b.currentIndexChanged.connect(self._on_compare_inputs_changed)
+        cl.addWidget(self.compare_csv_b)
+        self.compare_graph_b = QComboBox()
+        self.compare_graph_b.setObjectName("GraphViewerCompareGraphB")
+        self.compare_graph_b.currentIndexChanged.connect(self._on_compare_inputs_changed)
+        cl.addWidget(self.compare_graph_b)
+        cl.addStretch(1)
+        self._compare_left_scroll.setWidget(self._compare_left_inner)
+        compare_outer.addWidget(self._compare_left_scroll)
+
+        self._compare_scroll_a = QScrollArea()
+        self._compare_scroll_a.setObjectName("GraphViewerCompareScrollA")
+        self._compare_scroll_a.setWidgetResizable(True)
+        self._compare_scroll_a.setFrameShape(QFrame.NoFrame)
+        self.compare_label_a = QLabel("—")
+        self.compare_label_a.setObjectName("GraphViewerCompareImageA")
+        self.compare_label_a.setAlignment(Qt.AlignCenter)
+        self.compare_label_a.setWordWrap(True)
+        self.compare_label_a.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Expanding)
+        self._compare_scroll_a.setWidget(self.compare_label_a)
+
+        self._compare_scroll_b = QScrollArea()
+        self._compare_scroll_b.setObjectName("GraphViewerCompareScrollB")
+        self._compare_scroll_b.setWidgetResizable(True)
+        self._compare_scroll_b.setFrameShape(QFrame.NoFrame)
+        self.compare_label_b = QLabel("—")
+        self.compare_label_b.setObjectName("GraphViewerCompareImageB")
+        self.compare_label_b.setAlignment(Qt.AlignCenter)
+        self.compare_label_b.setWordWrap(True)
+        self.compare_label_b.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Expanding)
+        self._compare_scroll_b.setWidget(self.compare_label_b)
+
+        right_split = QHBoxLayout()
+        right_split.setContentsMargins(0, 0, 0, 0)
+        right_split.addWidget(self._compare_scroll_a, 1)
+        right_split.addWidget(self._compare_scroll_b, 1)
+        compare_outer.addLayout(right_split, stretch=1)
+
+        self._compare_pix_a: Optional[QPixmap] = None
+        self._compare_pix_b: Optional[QPixmap] = None
+        self._compare_syncing = False
+
+    def _on_main_tab_changed(self, index: int) -> None:
+        if index == self.TAB_COMPARE:
+            # Compare is populated/updated in set_graphs / _apply_selected_csv. Re-syncing here
+            # re-cleared combos, re-ran slow kaleido work, and reset selection on every visit.
+            self._rescale_compare_images()
+        elif index == self.TAB_CROSS:
+            # Backlog #1: re-apply enablement / signals when re-entering this tab.
+            if self._results_by_csv and self.csv_combo.count() > 0:
+                self._apply_crosscorr_for_current_folder_csv()
+            elif self._last_single_run_df is not None:
+                self._enable_crosscorr(self._last_single_run_df)
+
+    def _graph_datasets(self) -> List[Tuple[str, Dict[str, GraphSource]]]:
+        if self._graphs_by_csv and len(self._csv_order) > 1:
+            return [(p, self._graphs_by_csv.get(p, {})) for p in self._csv_order]
+        key = str(self._context_csv_id) if self._context_csv_id else "current"
+        return [(key, dict(self._graphs))]
+
+    def _has_any_graphs(self) -> bool:
+        for _p, g in self._graph_datasets():
+            if g:
+                return True
+        return False
+
+    def _dict_for_compare_csv(self, csv_path: str) -> Dict[str, GraphSource]:
+        if self._graphs_by_csv and len(self._csv_order) > 1:
+            return dict(self._graphs_by_csv.get(csv_path, {}))
+        return dict(self._graphs)
+
+    def _sync_compare_pane(self) -> None:
+        if not self._has_any_graphs():
+            self.tab_widget.setTabEnabled(self.TAB_COMPARE, False)
+            return
+        self.tab_widget.setTabEnabled(self.TAB_COMPARE, True)
+        dsets = self._graph_datasets()
+        paths = [p for p, _g in dsets if _g]
+        if not paths:
+            self.tab_widget.setTabEnabled(self.TAB_COMPARE, False)
+            return
+        multi = len(paths) > 1
+        old_ca = self.compare_csv_a.currentData()
+        old_cb = self.compare_csv_b.currentData()
+        old_ga = self.compare_graph_a.currentData()
+        old_gb = self.compare_graph_b.currentData()
+        self._compare_syncing = True
+        try:
+            for combo in (self.compare_csv_a, self.compare_csv_b):
+                combo.blockSignals(True)
+                combo.clear()
+                for p in paths:
+                    combo.addItem(Path(p).name if p != "current" else "(current file)", p)
+                combo.setVisible(multi)
+            for combo, prev, fallback in (
+                (self.compare_csv_a, old_ca, 0),
+                (self.compare_csv_b, old_cb, min(1, len(paths) - 1) if multi and len(paths) > 1 else 0),
+            ):
+                if prev is not None and combo.findData(prev) >= 0:
+                    combo.setCurrentIndex(combo.findData(prev))
+                else:
+                    combo.setCurrentIndex(min(fallback, max(0, combo.count() - 1)))
+        finally:
+            for combo in (self.compare_csv_a, self.compare_csv_b):
+                combo.blockSignals(False)
+        pa = str(self.compare_csv_a.currentData() or "current")
+        pb = str(self.compare_csv_b.currentData() or "current")
+        self._fill_compare_graph_combo(
+            self.compare_graph_a, self._dict_for_compare_csv(pa), preferred_name=old_ga
+        )
+        self._fill_compare_graph_combo(
+            self.compare_graph_b, self._dict_for_compare_csv(pb), preferred_name=old_gb
+        )
+        self._update_compare_images()
+        self._compare_syncing = False
+
+    def _refill_compare_graph_combos(self) -> None:
+        old_ga = self.compare_graph_a.currentData()
+        old_gb = self.compare_graph_b.currentData()
+        pa = str(self.compare_csv_a.currentData() or "current")
+        pb = str(self.compare_csv_b.currentData() or "current")
+        self._fill_compare_graph_combo(
+            self.compare_graph_a, self._dict_for_compare_csv(pa), preferred_name=old_ga
+        )
+        self._fill_compare_graph_combo(
+            self.compare_graph_b, self._dict_for_compare_csv(pb), preferred_name=old_gb
+        )
+
+    def _fill_compare_graph_combo(
+        self, combo: QComboBox, graph_dict: Dict[str, GraphSource], preferred_name: Optional[str] = None
+    ) -> None:
+        names = list(graph_dict.keys())
+        combo.blockSignals(True)
+        combo.clear()
+        for n in names:
+            combo.addItem(n, n)
+        if names:
+            if preferred_name and preferred_name in graph_dict:
+                i = next((k for k, n in enumerate(names) if n == preferred_name), 0)
+                combo.setCurrentIndex(i)
+            else:
+                combo.setCurrentIndex(0)
+        combo.blockSignals(False)
+
+    def _on_compare_inputs_changed(self, *_args) -> None:
+        if self._compare_syncing:
+            return
+        if self.sender() in (self.compare_csv_a, self.compare_csv_b):
+            self._refill_compare_graph_combos()
+        self._update_compare_images()
+
+    def _source_to_pixmap_safe(self, source: Optional[GraphSource]) -> Optional[QPixmap]:
+        if source is None:
+            return None
+        if isinstance(source, go.Figure):
+            if not self._kaleido_available:
+                return None
+            try:
+                png_bytes = pio.to_image(source, format="png", scale=2)
+                pix = QPixmap()
+                if pix.loadFromData(png_bytes) and not pix.isNull():
+                    return pix
+            except Exception:
+                return None
+            return None
+        try:
+            p = QPixmap(str(source))
+            return p if not p.isNull() else None
+        except Exception:
+            return None
+
+    def _update_compare_images(self) -> None:
+        if not self._has_any_graphs():
+            self.compare_label_a.setText("No graphs to compare.")
+            self.compare_label_b.setText("No graphs to compare.")
+            self._compare_pix_a = None
+            self._compare_pix_b = None
+            return
+        ca = self.compare_csv_a.currentData() or "current"
+        cb = self.compare_csv_b.currentData() or "current"
+        da = self._dict_for_compare_csv(str(ca) if ca is not None else "")
+        db = self._dict_for_compare_csv(str(cb) if cb is not None else "")
+        na = self.compare_graph_a.currentData()
+        nb = self.compare_graph_b.currentData()
+        for lbl, d, n, which in (
+            (self.compare_label_a, da, na, "A"),
+            (self.compare_label_b, db, nb, "B"),
+        ):
+            if not n or n not in d:
+                lbl.setText(f"Select graph {which}.")
+                lbl.setPixmap(QPixmap())
+                if which == "A":
+                    self._compare_pix_a = None
+                else:
+                    self._compare_pix_b = None
+            else:
+                pix = self._source_to_pixmap_safe(d.get(n))
+                if pix and not pix.isNull():
+                    if which == "A":
+                        self._compare_pix_a = pix
+                    else:
+                        self._compare_pix_b = pix
+                else:
+                    if which == "A":
+                        self._compare_pix_a = None
+                    else:
+                        self._compare_pix_b = None
+                    lbl.setText(
+                        "Could not render (install kaleido for Plotly, or use PNG outputs)."
+                    )
+                    lbl.setPixmap(QPixmap())
+        self._rescale_compare_images()
+
+    @staticmethod
+    def _fit_pixmap_to_box(full_pix: QPixmap, w: int, h: int) -> QPixmap:
+        """Largest size that fits in w×h, aspect ratio preserved (no vertical overflow from width-only fit)."""
+        if full_pix is None or full_pix.isNull():
+            return QPixmap()
+        w = max(1, w)
+        h = max(1, h)
+        return full_pix.scaled(w, h, Qt.KeepAspectRatio, Qt.SmoothTransformation)
+
+    def _rescale_compare_images(self) -> None:
+        for scroll, full_pix, label in (
+            (self._compare_scroll_a, self._compare_pix_a, self.compare_label_a),
+            (self._compare_scroll_b, self._compare_pix_b, self.compare_label_b),
+        ):
+            if not full_pix or full_pix.isNull():
+                continue
+            vp = scroll.viewport().size()
+            w = max(50, vp.width() - 8)
+            h = max(50, vp.height() - 8)
+            scaled = self._fit_pixmap_to_box(full_pix, w, h)
+            label.setPixmap(scaled)
+            label.setText("")
 
     def set_context(self, csv_id: Optional[str], config_path: Optional[str], csv_files: Optional[List[str]] = None):
         self._context_csv_id = csv_id
@@ -332,11 +646,15 @@ class GraphViewerScene(QWidget):
         config: Dict[str, Any] = None,
         *,
         results_df: Optional[pd.DataFrame] = None,
+        save_progress: Optional[Callable[[int, int, str], None]] = None,
+        on_preparing_viewer: Optional[Callable[[], None]] = None,
+        is_cancelled: Optional[Callable[[], bool]] = None,
     ):
         """Replace all graphs; clears multi-CSV state when switching to single-CSV view."""
         self._graphs_by_csv = None
         self._results_by_csv = None
         self._csv_order = []
+        self._last_single_run_df = None
         try:
             self.csv_combo.blockSignals(True)
             self.csv_combo.clear()
@@ -369,9 +687,15 @@ class GraphViewerScene(QWidget):
                 "  conda install -c conda-forge python-kaleido"
             )
             if isinstance(results_df, pd.DataFrame) and not results_df.empty:
+                self._last_single_run_df = results_df
                 self._enable_crosscorr(results_df)
             else:
+                self._last_single_run_df = None
                 self._clear_crosscorr_state()
+            if on_preparing_viewer is not None:
+                on_preparing_viewer()
+                QApplication.processEvents()
+            self._sync_compare_pane()
             return
 
         if self.list.count() > 0:
@@ -381,13 +705,29 @@ class GraphViewerScene(QWidget):
             self._show_empty_state("No graphs available.")
 
         if config and self.current_session is not None and self._out_dir is not None:
-            for name, fig in self._graphs.items():
+            fig_items = [
+                (n, f) for n, f in self._graphs.items() if isinstance(f, go.Figure)
+            ]
+            ntot = len(fig_items)
+            for i, (name, fig) in enumerate(fig_items, start=1):
+                if is_cancelled is not None and is_cancelled():
+                    raise CalculationAborted()
+                if save_progress is not None:
+                    save_progress(i, ntot, name)
                 save_to_html(fig, name, self._out_dir, config, self.current_session)
+                QApplication.processEvents()
+
+        if on_preparing_viewer is not None:
+            on_preparing_viewer()
+            QApplication.processEvents()
 
         if isinstance(results_df, pd.DataFrame) and not results_df.empty:
+            self._last_single_run_df = results_df
             self._enable_crosscorr(results_df)
         else:
+            self._last_single_run_df = None
             self._clear_crosscorr_state()
+        self._sync_compare_pane()
 
     def set_graphs_by_csv(
         self,
@@ -397,6 +737,7 @@ class GraphViewerScene(QWidget):
         results_by_csv: Optional[Dict[str, pd.DataFrame]] = None,
     ):
         """Graphs grouped by CSV path; Graphs-tab Prev/Next + combo; optional per-file metrics for cross-corr."""
+        self._last_single_run_df = None
         self._graphs_by_csv = dict(graphs_by_csv or {})
         self._csv_order = list(self._graphs_by_csv.keys())
         self._results_by_csv = (
@@ -515,6 +856,9 @@ class GraphViewerScene(QWidget):
             self.list.setCurrentRow(0)
         else:
             self._show_empty_state("No graphs available.")
+        if self._results_by_csv:
+            self._apply_crosscorr_for_current_folder_csv()
+        self._sync_compare_pane()
 
     def save_folder_graphs(
         self,
@@ -523,6 +867,9 @@ class GraphViewerScene(QWidget):
         config_path: str,
         graphs_by_csv: Dict[str, Dict[str, GraphSource]],
         config: Dict[str, Any],
+        *,
+        save_progress: Optional[Callable[[int, int, str], None]] = None,
+        is_cancelled: Optional[Callable[[], bool]] = None,
     ) -> None:
         """
         Persist folder-run graph outputs under:
@@ -552,13 +899,21 @@ class GraphViewerScene(QWidget):
             out_dir.mkdir(parents=True, exist_ok=True)
             csv_dir_for_path[csv_path] = out_dir
 
+        n_total = count_figures_in_folder_runs(graphs_by_csv)
+        done = 0
         for csv_path, graphs in (graphs_by_csv or {}).items():
             out_dir = csv_dir_for_path.get(csv_path)
             if out_dir is None:
                 continue
+            csv_label = Path(csv_path).name
             for title, src in (graphs or {}).items():
                 if not isinstance(src, go.Figure):
                     continue
+                if is_cancelled is not None and is_cancelled():
+                    raise CalculationAborted()
+                done += 1
+                if save_progress is not None and n_total > 0:
+                    save_progress(done, n_total, f"{csv_label}  —  {title}")
                 try:
                     fname = _safe_filename(title) or "graph"
                     html_path = out_dir / f"{fname}.html"
@@ -586,7 +941,9 @@ class GraphViewerScene(QWidget):
                             csv_folder_id, config_path, csv_path, str(html_path)
                         )
                 except Exception:
-                    continue
+                    pass
+                # Keep the UI responsive during long Plotly I/O (folder runs).
+                QApplication.processEvents()
 
         try:
             self.current_session.save()
@@ -662,7 +1019,9 @@ class GraphViewerScene(QWidget):
 
         self.set_graphs(graphs, config=config, results_df=results_df)
 
-    def build_graphs_with_progress(self, data, progress_callback):
+    def build_graphs_with_progress(
+        self, data, progress_callback, is_cancelled: Optional[Callable[[], bool]] = None
+    ):
         """
         Build graphs one-by-one, calling progress_callback(n, total, graph_name)
         for each. Returns (graphs_dict, config) or (None, None) if invalid.
@@ -682,22 +1041,30 @@ class GraphViewerScene(QWidget):
         graphs: Dict[str, GraphSource] = {}
         index = 0
         for name, fig in _iter_dot_plot_graphs(results_df, config, warnings):
+            if is_cancelled is not None and is_cancelled():
+                raise CalculationAborted()
             index += 1
             progress_callback(index, total, name)
             graphs[name] = fig
         for name, fig in _iter_fin_tail_graphs(results_df, config, warnings):
+            if is_cancelled is not None and is_cancelled():
+                raise CalculationAborted()
             index += 1
             progress_callback(index, total, name)
             graphs[name] = fig
         for name, fig in _iter_spine_graphs(
             results_df, config, parsed_points, warnings
         ):
+            if is_cancelled is not None and is_cancelled():
+                raise CalculationAborted()
             index += 1
             progress_callback(index, total, name)
             graphs[name] = fig
         head_graphs, head_warnings = build_head_plot_graphs(results_df, config)
         warnings.extend(head_warnings)
         for name, fig in head_graphs.items():
+            if is_cancelled is not None and is_cancelled():
+                raise CalculationAborted()
             index += 1
             progress_callback(index, total, name)
             graphs[name] = fig
@@ -720,14 +1087,17 @@ class GraphViewerScene(QWidget):
             self.signal_b_combo.blockSignals(False)
         except Exception:
             pass
-        self.tab_widget.setTabEnabled(1, False)
+        self.tab_widget.setTabEnabled(self.TAB_CROSS, False)
+        if hasattr(self, "compute_crosscorr_btn"):
+            self.compute_crosscorr_btn.setEnabled(False)
 
     def _enable_crosscorr(self, df: pd.DataFrame):
         try:
             signals = get_available_signals(df)
             if len(signals) < 2:
                 self._crosscorr_available = False
-                self.tab_widget.setTabEnabled(1, False)
+                self.tab_widget.setTabEnabled(self.TAB_CROSS, False)
+                self.compute_crosscorr_btn.setEnabled(False)
                 return
 
             self._crosscorr_available = True
@@ -750,12 +1120,14 @@ class GraphViewerScene(QWidget):
             self.signal_a_combo.blockSignals(False)
             self.signal_b_combo.blockSignals(False)
 
-            self.tab_widget.setTabEnabled(1, True)
+            self.tab_widget.setTabEnabled(self.TAB_CROSS, True)
+            self.compute_crosscorr_btn.setEnabled(True)
 
         except Exception as e:
             print(f"[GraphViewerScene] Could not enable cross-correlation: {e}")
             self._crosscorr_available = False
-            self.tab_widget.setTabEnabled(1, False)
+            self.tab_widget.setTabEnabled(self.TAB_CROSS, False)
+            self.compute_crosscorr_btn.setEnabled(False)
 
     def _compute_crosscorr(self):
         if not self._crosscorr_available:
@@ -807,8 +1179,9 @@ class GraphViewerScene(QWidget):
             return
 
         viewport_size = self.crosscorr_scroll.viewport().size()
-        target_w = max(50, viewport_size.width() - 16)
-        scaled = self._current_crosscorr_pixmap.scaledToWidth(target_w, Qt.SmoothTransformation)
+        w = max(50, viewport_size.width() - 16)
+        h = max(50, viewport_size.height() - 16)
+        scaled = self._fit_pixmap_to_box(self._current_crosscorr_pixmap, w, h)
         self.crosscorr_label.setPixmap(scaled)
         self.crosscorr_label.setText("")
 
@@ -868,6 +1241,8 @@ class GraphViewerScene(QWidget):
             self._update_scaled_pixmap()
         if getattr(self, "_current_crosscorr_pixmap", None) is not None:
             self._update_crosscorr_pixmap()
+        if self.tab_widget.currentIndex() == self.TAB_COMPARE:
+            self._rescale_compare_images()
 
     def prepare_for_session_load(self) -> None:
         """Clear viewer UI before attaching a new session (avoids stale list/graphs)."""
@@ -875,6 +1250,7 @@ class GraphViewerScene(QWidget):
         self._results_by_csv = None
         self._csv_order = []
         self._data = None
+        self._last_single_run_df = None
         try:
             self.csv_combo.blockSignals(True)
             self.csv_combo.clear()
@@ -894,6 +1270,20 @@ class GraphViewerScene(QWidget):
         self._show_empty_state("No graphs available.")
         self.set_context(None, None, None)
         self._clear_crosscorr_state()
+        try:
+            self.tab_widget.setTabEnabled(self.TAB_COMPARE, False)
+            self._compare_pix_a = None
+            self._compare_pix_b = None
+            self.compare_label_a.setText("—")
+            self.compare_label_b.setText("—")
+            self.compare_label_a.setPixmap(QPixmap())
+            self.compare_label_b.setPixmap(QPixmap())
+            for c in (self.compare_csv_a, self.compare_csv_b, self.compare_graph_a, self.compare_graph_b):
+                c.blockSignals(True)
+                c.clear()
+                c.blockSignals(False)
+        except Exception:
+            pass
 
     def load_session(self, session, *, preload_saved_graphs: bool = False):
         """Attach session and output paths; optionally restore PNGs from disk.
@@ -1040,10 +1430,9 @@ class GraphViewerScene(QWidget):
         if not self._original_pixmap:
             return
         viewport_size: QSize = self.scroll.viewport().size()
-        target_w = max(50, viewport_size.width() - 16)
-        scaled = self._original_pixmap.scaledToWidth(
-            target_w, Qt.SmoothTransformation
-        )
+        w = max(50, viewport_size.width() - 16)
+        h = max(50, viewport_size.height() - 16)
+        scaled = self._fit_pixmap_to_box(self._original_pixmap, w, h)
         self.image_label.setPixmap(scaled)
         self.image_label.setText("")
 

--- a/src/ui/main_panels/select_run_widget.py
+++ b/src/ui/main_panels/select_run_widget.py
@@ -1,8 +1,12 @@
+from __future__ import annotations
+
 import json
+import threading
 from os import path
 from pathlib import Path
 
-from PyQt5.QtCore import QEvent, Qt, pyqtSignal
+from PyQt5.QtCore import QObject, QEvent, QThread, Qt, QSize, pyqtSignal, pyqtSlot
+from typing import Any
 from PyQt5.QtGui import QIcon
 from PyQt5.QtWidgets import (
     QApplication,
@@ -24,11 +28,75 @@ import src.core.calculations.Driver as calculations
 import src.core.parsing.Parser as parser
 
 from ui.components.branding import view_output_tool_icon
+from ui.components.scene_help import create_scene_help_button
 
 from src.app_platform.paths import default_sample_config, default_sample_csv
 from src.app_platform.paths import images_dir
 
 FOLDER_ICON = images_dir() / "folder-black.svg"
+
+
+class _SingleCalcWorker(QObject):
+    """Background parse + `run_calculations` for single-CSV runs (stays off the UI thread)."""
+
+    ok = pyqtSignal(object)  # payload dict
+    err = pyqtSignal(str)
+    cancelled = pyqtSignal()
+
+    def __init__(self, csv_path: str, config: dict[str, Any], cancel_event: threading.Event):
+        super().__init__()
+        self._csv = csv_path
+        self._config = config
+        self._ce = cancel_event
+
+    def _cancelled(self) -> bool:
+        return self._ce.is_set()
+
+    @pyqtSlot()
+    def work(self) -> None:
+        from src.core.calculations.cancelled import CalculationAborted
+
+        th = self.thread()
+        try:
+            if self._cancelled():
+                self.cancelled.emit()
+                return
+            try:
+                parsed_points = parser.parse_dlc_csv(self._csv, self._config)
+            except Exception as e:
+                self.err.emit(str(e))
+                return
+            if self._cancelled():
+                self.cancelled.emit()
+                return
+            try:
+                results = calculations.run_calculations(
+                    parsed_points, self._config, cancel_check=self._cancelled
+                )
+            except CalculationAborted:
+                self.cancelled.emit()
+                return
+            except Exception as e:
+                self.err.emit(str(e))
+                return
+            if results is None:
+                self.err.emit("The calculation pipeline returned no results.")
+                return
+            if self._cancelled():
+                self.cancelled.emit()
+                return
+            self.ok.emit(
+                {
+                    "results_df": results,
+                    "config": self._config,
+                    "csv_path": self._csv,
+                    "parsed_points": parsed_points,
+                }
+            )
+        finally:
+            if th is not None:
+                th.quit()
+
 
 def _is_displayable_graph_png(p) -> bool:
     try:
@@ -56,15 +124,47 @@ class ConfigSelectionScene(QWidget):
         self.config_path = None
         self.previous_settings = {"csv_path": None, "config_path": None}
         self._tree_theme = "dark"
+        # Monotonic run progress: never show a lower % than a prior step in the same run (#91).
+        self._progress_run_floor: int = 0
+        self._progress_run_busy: bool = False
+        self._calculation_run_active: bool = False
+        self._cancel_event = threading.Event()
+        self._calc_thread: QThread | None = None
+        self._calc_worker: _SingleCalcWorker | None = None
 
         # --- Layout setup ---
         layout = QVBoxLayout(self)
+        layout.setContentsMargins(40, 30, 40, 30)
         layout.setSpacing(16)
 
+        head_row = QHBoxLayout()
+        head_row.setContentsMargins(0, 0, 0, 0)
+        head_row.addStretch(1)
         header = QLabel("Select Configuration")
         header.setObjectName("ConfigSelectionHeader")
-        header.setAlignment(Qt.AlignCenter)
-        layout.addWidget(header)
+        head_row.addWidget(header, 0, Qt.AlignVCenter)
+        head_row.addStretch(1)
+        head_row.addWidget(
+            create_scene_help_button(
+                self,
+                title="Select Configuration",
+                paragraph=(
+                    "In the session file tree, select a CSV and a configuration JSON under it, then click Run Calculation. "
+                    "Click a CSV in the first column, or a .json in the second column, to make that selection. "
+                    "Click the line-graph icon in the right column to open graph outputs. "
+                    "(Or double click a .json in the name column to select and start a run from there.) "
+                    "Right click a .json to delete it, use Generate copy…, or open View output when that row has saved graphs. "
+                    "Right click a CSV row in the first column to delete the CSV. "
+                    "The progress bar roughly shows the amount of analysis completed."
+                ),
+                tips=(
+                    "While a run is in progress, the main button reads Stop — click it to cancel, then you can start a different run.",
+                ),
+            ),
+            0,
+            Qt.AlignRight | Qt.AlignTop,
+        )
+        layout.addLayout(head_row)
 
         self.status_label = QLabel("Select a CSV and Config to run calculations.")
         self.status_label.setObjectName("ConfigSelectionStatus")
@@ -79,6 +179,7 @@ class ConfigSelectionScene(QWidget):
         self.file_tree.setAttribute(Qt.WA_StyledBackground, True)
         self.file_tree.setHeaderLabels(["CSV Files", "Configurations", ""])
         self.file_tree.setColumnCount(3)
+        self.file_tree.setIconSize(QSize(16, 16))
         self.file_tree.setColumnWidth(0, 200)
         _th = self.file_tree.header()
         _th.setSectionResizeMode(0, QHeaderView.Interactive)
@@ -86,6 +187,7 @@ class ConfigSelectionScene(QWidget):
         _th.setSectionResizeMode(2, QHeaderView.Fixed)
         self.file_tree.setColumnWidth(2, 34)
         self.file_tree.itemClicked.connect(self.handle_tree_click)
+        self.file_tree.itemDoubleClicked.connect(self._on_tree_item_double_clicked)
         self.file_tree.setContextMenuPolicy(Qt.CustomContextMenu)
         self.file_tree.customContextMenuRequested.connect(self._on_tree_context_menu)
         self.file_tree.viewport().installEventFilter(self)
@@ -97,7 +199,7 @@ class ConfigSelectionScene(QWidget):
         self.calc_button = QPushButton("Run Calculation")
         self.calc_button.setObjectName("ConfigSelectionCalcButton")
         self.calc_button.setEnabled(False)
-        self.calc_button.clicked.connect(self.calculate)
+        self.calc_button.clicked.connect(self._on_calc_button_clicked)
         self.toggle_button = QPushButton()
         self.toggle_button.setObjectName("ConfigSelectionTestToggle")
         self.toggle_button.setCheckable(True)
@@ -136,7 +238,8 @@ class ConfigSelectionScene(QWidget):
         self.setLayout(layout)
 
     def eventFilter(self, obj, event):
-        """Single-click graph icon column (right of JSON name) opens View Output."""
+        """Open View Output on release in the graph column. The cell is only ~34px; the icon is
+        left-aligned, so a right-edge hit test could miss the icon entirely."""
         if (
             obj is self.file_tree.viewport()
             and event.type() == QEvent.MouseButtonRelease
@@ -149,16 +252,23 @@ class ConfigSelectionScene(QWidget):
                 if item is None:
                     return super().eventFilter(obj, event)
                 cfg_data = item.data(1, Qt.UserRole)
-                if cfg_data:
-                    parent = item.parent()
-                    csv_for = parent.data(0, Qt.UserRole) if parent else None
-                    if csv_for and self._config_row_has_graphs(csv_for, cfg_data):
-                        self.view_output_requested.emit(csv_for, cfg_data)
+                if not cfg_data:
+                    return super().eventFilter(obj, event)
+                r = self.file_tree.visualRect(self.file_tree.indexFromItem(item, 2))
+                if not r.contains(pos):
+                    return super().eventFilter(obj, event)
+                parent = item.parent()
+                csv_for = parent.data(0, Qt.UserRole) if parent else None
+                if csv_for and self._config_row_has_graphs(csv_for, cfg_data):
+                    self.view_output_requested.emit(csv_for, cfg_data)
+                return True
         return super().eventFilter(obj, event)
 
     def _update_calc_button_state(self):
-        enabled = bool(self.csv_path and self.config_path)
-        self.calc_button.setEnabled(enabled)
+        if self._calculation_run_active:
+            self.calc_button.setEnabled(True)
+            return
+        self.calc_button.setEnabled(bool(self.csv_path and self.config_path))
 
     def set_selected_paths(self, csv_path: str | None, config_path: str | None) -> None:
         """Set CSV + config selection (e.g. session resume) and refresh Run button / status."""
@@ -176,6 +286,9 @@ class ConfigSelectionScene(QWidget):
 
     def reset_selection_ui(self) -> None:
         """Clear tree selection state when switching sessions."""
+        if self._calculation_run_active:
+            self.request_cancel_calculation()
+        self.finish_calculation_run()
         self.csv_path = None
         self.config_path = None
         self.previous_settings = {"csv_path": None, "config_path": None}
@@ -452,12 +565,32 @@ class ConfigSelectionScene(QWidget):
         self.populate_tree()
         self.toast_requested.emit("Removed", f"Removed {path.basename(config_path)} from the session.")
 
+    def _on_tree_item_double_clicked(self, item, column):
+        """Double-click a config JSON row to select it and start calculation (if not already running)."""
+        cfg_data = item.data(1, Qt.UserRole)
+        if not cfg_data:
+            return
+        if column != 1:
+            return
+        p = str(cfg_data)
+        if not p.lower().endswith(".json"):
+            return
+        self.handle_tree_click(item, 1)
+        if self._calculation_run_active:
+            return
+        if self.csv_path and self.config_path:
+            self.calculate()
+
     def handle_tree_click(self, item, column):
         """Handle user clicking a CSV or config in the tree."""
         csv_data = item.data(0, Qt.UserRole)
         cfg_data = item.data(1, Qt.UserRole)
 
         if cfg_data:
+            if column == 2:
+                return
+            if column != 1:
+                return
             parent = item.parent()
             csv_for = parent.data(0, Qt.UserRole) if parent else None
             if not csv_for:
@@ -482,6 +615,8 @@ class ConfigSelectionScene(QWidget):
             return
 
         if csv_data and not cfg_data:
+            if column != 0:
+                return
             self.csv_path = csv_data
             self.config_path = None
             self.status_label.setText(f"Selected CSV: {path.basename(csv_data)}")
@@ -513,23 +648,143 @@ class ConfigSelectionScene(QWidget):
                 self.status_label.setText("Select a CSV and Config to run calculations.")
                 self._update_calc_button_state()
 
+    def start_progress_run(self) -> None:
+        """Start a new determinate run (e.g. graph build in shell) after parse/calc; resets monotonic floor."""
+        self._progress_run_floor = 0
+        if self._progress_run_busy:
+            self.set_progress_busy(False)
+        if self.progress_bar.isHidden():
+            self.progress_bar.setRange(0, 100)
+
+    def set_progress_busy(self, active: bool, message: str = "") -> None:
+        """
+        Indeterminate bar while the pipeline has no sub-milestones to report
+        (e.g. long run_calculations on the UI thread). Does not set a percentage.
+        """
+        self._progress_run_busy = bool(active)
+        if not active:
+            self.progress_bar.setRange(0, 100)
+            return
+        self._progress_run_floor = 0
+        self.progress_bar.setRange(0, 0)
+        self.progress_bar.setValue(0)
+        self.progress_bar.show()
+        self.progress_label.show()
+        if message:
+            self.progress_label.setText(message)
+        else:
+            self.progress_label.setText("Working…")
+        QApplication.processEvents()
+
     def set_progress(self, n, total, graph_name):
-        """Update progress bar and label: [N]/[Total] - [Graph Name]. Call with total=0 to hide."""
+        """
+        Update progress. [n]/[total] is the current step; graph_name is status text.
+        total<=0: hide the bar. Percent never goes down within a run unless reset (hide) or
+        start_progress_run() / set_progress(0,0,).
+        """
         if total <= 0:
             self.progress_bar.hide()
             self.progress_label.hide()
+            self.progress_bar.setRange(0, 100)
             self.progress_bar.setValue(0)
             self.progress_label.setText("")
+            self._progress_run_busy = False
+            self._progress_run_floor = 0
             return
+        if self._progress_run_busy:
+            self._progress_run_busy = False
+            self.progress_bar.setRange(0, 100)
         self.progress_bar.show()
         self.progress_label.show()
         self.progress_bar.setMaximum(100)
-        self.progress_bar.setValue(int(100 * n / total) if total else 0)
-        if graph_name == "Loading graphs...":
-            self.progress_label.setText("Loading Graphs...")
+        raw = (100 * int(n)) // int(total) if total else 0
+        if raw < self._progress_run_floor:
+            raw = self._progress_run_floor
         else:
-            self.progress_label.setText(f"{n}/{total} - {graph_name}")
+            self._progress_run_floor = raw
+        self.progress_bar.setValue(min(100, raw))
+        if graph_name == "Loading graphs...":
+            self.progress_label.setText("Loading Graphs…")
+        else:
+            self.progress_label.setText(f"{n}/{total} — {graph_name}")
         QApplication.processEvents()
+
+    # ==============================================================
+    # Calculation run control (Run / Stop)
+    # ==============================================================
+
+    def begin_calculation_run(self) -> None:
+        self._cancel_event.clear()
+        self._calculation_run_active = True
+        self.calc_button.setText("Stop Calculation")
+        self.calc_button.setEnabled(True)
+
+    def finish_calculation_run(self) -> None:
+        self._cancel_event.clear()
+        self._calculation_run_active = False
+        self.calc_button.setText("Run Calculation")
+        self._update_calc_button_state()
+
+    def request_cancel_calculation(self) -> None:
+        self._cancel_event.set()
+
+    def is_calculation_cancelled(self) -> bool:
+        return self._cancel_event.is_set()
+
+    def _on_calc_button_clicked(self) -> None:
+        if self._calculation_run_active:
+            self.request_cancel_calculation()
+        else:
+            self.calculate()
+
+    def _on_single_worker_ok(self, payload: object) -> None:
+        if not self._calculation_run_active:
+            return
+        self.set_progress_busy(False)
+        self.set_progress(0, 0, "")
+        self.status_label.setText("Calculation successful.")
+        self.data_generated.emit(payload)
+
+    def _on_single_worker_err(self, message: str) -> None:
+        self.set_progress_busy(False)
+        self.set_progress(0, 0, "")
+        self.status_label.setText("Error.")
+        self.toast_requested.emit("Calculation failed", message)
+        self.finish_calculation_run()
+
+    def _on_single_worker_cancelled(self) -> None:
+        self.set_progress_busy(False)
+        self.set_progress(0, 0, "")
+        if self.csv_path and self.config_path:
+            self.status_label.setText(
+                f"Ready: {path.basename(self.csv_path)} + {path.basename(self.config_path)}"
+            )
+        else:
+            self.status_label.setText("Select a CSV and Config to run calculations.")
+        self.finish_calculation_run()
+
+    def _setup_single_worker_thread(
+        self, config: dict[str, Any]
+    ) -> None:
+        if self._calc_thread is not None:
+            return
+        self._calc_thread = QThread()
+        self._calc_worker = _SingleCalcWorker(
+            str(self.csv_path), dict(config), self._cancel_event
+        )
+        self._calc_worker.moveToThread(self._calc_thread)
+        self._calc_thread.started.connect(self._calc_worker.work)
+        self._calc_worker.ok.connect(self._on_single_worker_ok, Qt.QueuedConnection)
+        self._calc_worker.err.connect(self._on_single_worker_err, Qt.QueuedConnection)
+        self._calc_worker.cancelled.connect(self._on_single_worker_cancelled, Qt.QueuedConnection)
+        self._calc_thread.finished.connect(self._on_single_thread_finished)
+        self._calc_thread.start()
+
+    def _on_single_thread_finished(self) -> None:
+        if self._calc_worker is not None:
+            self._calc_worker.deleteLater()
+            self._calc_worker = None
+        self._calc_thread = None
 
     # ==============================================================
     # Calculation Logic
@@ -537,6 +792,8 @@ class ConfigSelectionScene(QWidget):
 
     def calculate(self):
         """Run the calculation pipeline and emit data_generated with the payload."""
+        if self._calculation_run_active:
+            return
         if not self.csv_path or not self.config_path:
             self.toast_requested.emit(
                 "Missing files", "Select both a CSV and a config JSON before running."
@@ -578,46 +835,22 @@ class ConfigSelectionScene(QWidget):
                         "This folder has no CSV files recorded in the session.",
                     )
                     return
+                self.begin_calculation_run()
                 payload = {
                     "csv_folder": self.csv_path,
                     "csv_files": files,
                     "config": config,
                     "config_path": self.config_path,
                 }
-                self.toast_requested.emit(
-                    "Running",
-                    f"Starting calculations for {len(files)} file(s) in this folder…",
-                )
+                # No toast: progress bar in the shell shows bulk status; avoids covering status text.
                 self.data_generated.emit(payload)
                 return
         except Exception:
             pass
 
-        self.status_label.setText("CSV parsed successfully, running calculations…")
-
-        try:
-            parsed_points = parser.parse_dlc_csv(self.csv_path, config)
-        except Exception as e:
-            self.toast_requested.emit("Parse error", str(e))
-            self.status_label.setText("Parse failed.")
-            return
-
-        results = calculations.run_calculations(parsed_points, config)
-
-        if results is None:
-            self.toast_requested.emit(
-                "Calculation failed",
-                "The calculation pipeline returned no results.",
-            )
-            self.status_label.setText("Calculation failed.")
-            self.data_generated.emit(None)
-        else:
-            self.toast_requested.emit("Done", "Calculation finished successfully.")
-            self.status_label.setText("Calculation successful.")
-            payload = {
-                "results_df": results,
-                "config": config,
-                "csv_path": self.csv_path,
-                "parsed_points": parsed_points,
-            }
-            self.data_generated.emit(payload)
+        self.set_progress(0, 0, "")
+        self.set_progress_busy(True, "Reading CSV and computing metrics (this can take a while)…")
+        self.status_label.setText("Working…")
+        QApplication.processEvents()
+        self.begin_calculation_run()
+        self._setup_single_worker_thread(config)

--- a/src/ui/main_panels/verify_panel.py
+++ b/src/ui/main_panels/verify_panel.py
@@ -19,6 +19,7 @@ from PyQt5.QtWidgets import (
 import pandas as pd
 
 from app_platform.paths import images_dir
+from ui.components.scene_help import create_scene_help_button
 from core.validation import csv_verifier as input_verifier
 from core.validation import json_verifier
 
@@ -44,10 +45,30 @@ class VerifyWorkspace(QWidget):
         main_layout.setContentsMargins(40, 30, 40, 30)
         main_layout.setSpacing(20)
 
+        head_row = QHBoxLayout()
+        head_row.setContentsMargins(0, 0, 0, 0)
+        head_row.addStretch(1)
         header = QLabel("Verify Input Files")
-        header.setAlignment(Qt.AlignHCenter)
         header.setStyleSheet("font-size: 24px; font-weight: bold;")
-        main_layout.addWidget(header)
+        head_row.addWidget(header, 0, Qt.AlignVCenter)
+        head_row.addStretch(1)
+        head_row.addWidget(
+            create_scene_help_button(
+                self,
+                title="Verify Input",
+                paragraph=(
+                    "To check your files before you run: click Upload CSV to pick one file, or Upload Multiple CSV to point at a whole folder. "
+                    "Click Upload JSON to pick a config, or click Generate JSON to open the builder when you need a new one. "
+                    "Read the console below for pass/fail and validation messages."
+                ),
+                tips=(
+                    "Use Upload Multiple CSV when you want batch runs in Select & Run with every CSV in that folder.",
+                ),
+            ),
+            0,
+            Qt.AlignRight | Qt.AlignTop,
+        )
+        main_layout.addLayout(head_row)
 
         csv_layout = QHBoxLayout()
         csv_label = QLabel("CSV File:")

--- a/src/ui/main_window_shell.py
+++ b/src/ui/main_window_shell.py
@@ -13,8 +13,9 @@ from pathlib import Path
 import pandas as pd
 
 import src.core.calculations.Driver as calculations
+from src.core.calculations.cancelled import CalculationAborted
 import src.core.parsing.Parser as parser
-from PyQt5.QtCore import QEvent, QPoint, QSize, Qt
+from PyQt5.QtCore import QEvent, QPoint, QTimer, QSize, Qt
 from PyQt5.QtGui import QKeySequence
 from PyQt5.QtWidgets import (
     QApplication,
@@ -36,7 +37,11 @@ from ui.components.error_toast import ErrorToast
 from ui.components.custom_title_bar import CustomTitleBar
 from ui.components.shell_menus import build_file_help_menus
 from ui.components.sidebar_tools import SidebarTools
-from ui.main_panels.graph_viewer_widget import get_graph_names_to_build
+from ui.main_panels.graph_viewer_widget import (
+    count_figures_in_folder_runs,
+    count_figures_in_graph_dict,
+    get_graph_names_to_build,
+)
 from ui.main_panels.workspace_widget import WorkspaceWidget
 from ui.popup_panels.generate_config_dialog import GenerateConfigDialog
 from ui.popup_panels.session_select_dialog import SessionSelectDialog
@@ -400,120 +405,275 @@ class MainShellWindow(QMainWindow):
             pass
         self._refresh_sidebar_capabilities()
 
-    def _handle_calculation_data(self, data) -> None:
-        """Orchestrate graph build after Run Calculation."""
-        if data is None:
-            return
-        config_scene = self.workspace.select_run_panel.selection
-        graphs_scene = self.workspace.view_output_panel.viewer
+    def _calculation_cancelled(self) -> bool:
+        return self.workspace.select_run_panel.selection.is_calculation_cancelled()
 
-        def progress_callback(n, total, graph_name):
-            config_scene.set_progress(n, total, graph_name)
-
-        if data and isinstance(data, dict) and data.get("csv_files"):
-            csv_files = list(data.get("csv_files") or [])
-            config = data.get("config") or {}
-            config_path = data.get("config_path") or (
-                config.get("config_path") if isinstance(config, dict) else None
-            )
-            csv_folder_id = data.get("csv_folder")
-            if not csv_files or not isinstance(config, dict):
-                self._show_error_toast("Bad Input", "Folder payload is missing CSV files or config.")
-                return
-            if not csv_folder_id or not config_path:
-                self._show_error_toast("Bad Input", "Folder payload is missing folder id or config path.")
-                return
-
-            results_by_csv = {}
-            parsed_by_csv = {}
-            total_files = len(csv_files)
-            for idx, csv_path in enumerate(csv_files, start=1):
-                config_scene.set_progress(idx, total_files, f"Calculating: {Path(csv_path).name}")
-                try:
-                    parsed_points = parser.parse_dlc_csv(csv_path, config)
-                    results_df = calculations.run_calculations(parsed_points, config)
-                except Exception as exc:
-                    config_scene.set_progress(0, 0, "")
-                    self._show_error_toast("Calculation Failed", f"Failed on {csv_path}:\n{exc}")
-                    return
-                results_by_csv[csv_path] = results_df
-                parsed_by_csv[csv_path] = parsed_points
-
-            total_graphs = 0
-            file_payloads = []
-            for csv_path in csv_files:
-                payload = {
-                    "results_df": results_by_csv[csv_path],
-                    "config": config,
-                    "csv_path": csv_path,
-                    "parsed_points": parsed_by_csv[csv_path],
-                }
-                names = get_graph_names_to_build(payload)
-                total_graphs += len(names)
-                file_payloads.append((csv_path, payload))
-
-            if total_graphs <= 0:
-                config_scene.set_progress(0, 0, "")
-                self._show_error_toast("No Graphs", "No graphs were requested or available for this config.")
-                return
-
-            graphs_by_csv = {}
-            done = 0
-
-            for csv_path, payload in file_payloads:
-                def progress_callback2(_n, _total, graph_name, _csv=csv_path):
-                    nonlocal done
-                    done += 1
-                    config_scene.set_progress(done, total_graphs, f"{Path(_csv).name} — {graph_name}")
-
-                graphs, _cfg = graphs_scene.build_graphs_with_progress(payload, progress_callback2)
-                if graphs is None:
-                    continue
-                graphs_by_csv[csv_path] = graphs
-
-            if not graphs_by_csv:
-                config_scene.set_progress(0, 0, "")
-                self._show_error_toast("No Graphs", "Graphs could not be generated for this folder.")
-                return
-
-            try:
-                graphs_scene.save_folder_graphs(
-                    csv_folder_id=csv_folder_id,
-                    csv_files=csv_files,
-                    config_path=config_path,
-                    graphs_by_csv=graphs_by_csv,
-                    config=config,
-                )
-            except Exception:
-                pass
-
-            graphs_scene.set_context(csv_id=csv_folder_id, config_path=config_path, csv_files=csv_files)
-            graphs_scene.set_graphs_by_csv(
-                graphs_by_csv,
-                config=config,
-                results_by_csv=results_by_csv,
-            )
+    def _deferred_view_output_after_ready(self, config_scene) -> None:
+        """After 100% 'Ready', hold ~1s so the label is readable, then open Graphs and clear the bar."""
+        def _go() -> None:
             self._persist_calculation_succeeded()
             self._show_view_output_panel()
             config_scene.set_progress(0, 0, "")
+
+        QTimer.singleShot(1000, _go)
+
+    def _handle_calculation_data(self, data) -> None:
+        """Orchestrate graph build after Run Calculation. Progress is monotonic; 100% only when UI is ready (#91)."""
+        config_scene = self.workspace.select_run_panel.selection
+        if data is None:
+            config_scene.finish_calculation_run()
+            return
+        graphs_scene = self.workspace.view_output_panel.viewer
+        is_cancel = self._calculation_cancelled
+
+        try:
+            if data and isinstance(data, dict) and data.get("csv_files"):
+                self._run_folder_calculation(
+                    data, config_scene, graphs_scene, is_cancel
+                )
+                return
+            self._run_single_csv_calculation(
+                data, config_scene, graphs_scene, is_cancel
+            )
+        except CalculationAborted:
+            config_scene.set_progress(0, 0, "")
+        finally:
+            config_scene.finish_calculation_run()
+
+    def _run_folder_calculation(
+        self, data, config_scene, graphs_scene, is_cancel
+    ) -> None:
+        if is_cancel():
+            raise CalculationAborted()
+        csv_files = list(data.get("csv_files") or [])
+        config = data.get("config") or {}
+        config_path = data.get("config_path") or (
+            config.get("config_path") if isinstance(config, dict) else None
+        )
+        csv_folder_id = data.get("csv_folder")
+        if not csv_files or not isinstance(config, dict):
+            self._show_error_toast("Bad Input", "Folder payload is missing CSV files or config.")
+            return
+        if not csv_folder_id or not config_path:
+            self._show_error_toast("Bad Input", "Folder payload is missing folder id or config path.")
             return
 
+        config_scene.set_progress(0, 0, "")
+        config_scene.start_progress_run()
+        total_files = len(csv_files)
+        tot_phase1 = 5 * max(1, total_files) + 3
+        step = 0
+        results_by_csv: dict = {}
+        parsed_by_csv: dict = {}
+        g_counts: list = []
+
+        for idx, csv_path in enumerate(csv_files, start=1):
+            if is_cancel():
+                raise CalculationAborted()
+            base = f"({idx}/{total_files})  {Path(csv_path).name}"
+            step += 1
+            config_scene.set_progress(step, tot_phase1, f"{base}  —  reading")
+            try:
+                parsed_points = parser.parse_dlc_csv(csv_path, config)
+            except Exception as exc:
+                config_scene.set_progress(0, 0, "")
+                self._show_error_toast("Calculation Failed", f"Failed on {csv_path}:\n{exc}")
+                return
+            QApplication.processEvents()
+            step += 1
+            config_scene.set_progress(step, tot_phase1, f"{base}  —  computing…")
+            try:
+                results_df = calculations.run_calculations(
+                    parsed_points, config, cancel_check=is_cancel
+                )
+            except CalculationAborted:
+                raise
+            except Exception as exc:
+                config_scene.set_progress(0, 0, "")
+                self._show_error_toast("Calculation Failed", f"Failed on {csv_path}:\n{exc}")
+                return
+            results_by_csv[csv_path] = results_df
+            parsed_by_csv[csv_path] = parsed_points
+            payload = {
+                "results_df": results_df,
+                "config": config,
+                "csv_path": csv_path,
+                "parsed_points": parsed_points,
+            }
+            g_counts.append(len(get_graph_names_to_build(payload)))
+            QApplication.processEvents()
+
+        total_graphs = int(sum(g_counts))
+        if total_graphs <= 0:
+            config_scene.set_progress(0, 0, "")
+            self._show_error_toast("No Graphs", "No graphs were requested or available for this config.")
+            return
+
+        total_steps = 2 * total_files + 2 * total_graphs + 2
+        config_scene.set_progress(
+            2 * total_files,
+            total_steps,
+            "All metrics ready — building graphs…",
+        )
+        QApplication.processEvents()
+
+        step = 2 * total_files
+        file_payloads = [
+            (
+                p,
+                {
+                    "results_df": results_by_csv[p],
+                    "config": config,
+                    "csv_path": p,
+                    "parsed_points": parsed_by_csv[p],
+                },
+            )
+            for p in csv_files
+        ]
+        graphs_by_csv: dict = {}
+        for csv_path, payload in file_payloads:
+            if is_cancel():
+                raise CalculationAborted()
+
+            def progress_callback2(
+                n: int, gtotal: int, graph_name: str, _csv: str = csv_path
+            ) -> None:
+                nonlocal step
+                if is_cancel():
+                    raise CalculationAborted()
+                step += 1
+                config_scene.set_progress(
+                    step,
+                    total_steps,
+                    f"{Path(_csv).name}  —  {n}/{gtotal}  —  {graph_name}",
+                )
+                QApplication.processEvents()
+
+            graphs, _cfg = graphs_scene.build_graphs_with_progress(
+                payload, progress_callback2, is_cancelled=is_cancel
+            )
+            if graphs is None:
+                continue
+            graphs_by_csv[csv_path] = graphs
+
+        if not graphs_by_csv:
+            config_scene.set_progress(0, 0, "")
+            self._show_error_toast("No Graphs", "Graphs could not be generated for this folder.")
+            return
+
+        n_save = count_figures_in_folder_runs(graphs_by_csv)
+        total_steps = 2 * total_files + total_graphs + n_save + 2
+        step = 2 * total_files + total_graphs
+
+        def _folder_save_progress(done: int, n: int, detail: str) -> None:
+            nonlocal step
+            if is_cancel():
+                raise CalculationAborted()
+            step = 2 * total_files + total_graphs + done
+            config_scene.set_progress(
+                step, total_steps, f"Saving {done}/{n}  —  {detail}"
+            )
+            QApplication.processEvents()
+
+        try:
+            graphs_scene.save_folder_graphs(
+                csv_folder_id=csv_folder_id,
+                csv_files=csv_files,
+                config_path=config_path,
+                graphs_by_csv=graphs_by_csv,
+                config=config,
+                save_progress=_folder_save_progress,
+                is_cancelled=is_cancel,
+            )
+        except CalculationAborted:
+            raise
+        except Exception:
+            pass
+        if is_cancel():
+            raise CalculationAborted()
+        QApplication.processEvents()
+        step = 2 * total_files + total_graphs + n_save
+        step += 1
+        config_scene.set_progress(step, total_steps, "Preparing graph viewer…")
+        QApplication.processEvents()
+        graphs_scene.set_context(
+            csv_id=csv_folder_id, config_path=config_path, csv_files=csv_files
+        )
+        graphs_scene.set_graphs_by_csv(
+            graphs_by_csv,
+            config=config,
+            results_by_csv=results_by_csv,
+        )
+        QApplication.processEvents()
+        step += 1
+        config_scene.set_progress(step, total_steps, "Ready")
+        QApplication.processEvents()
+        self._deferred_view_output_after_ready(config_scene)
+
+    def _run_single_csv_calculation(
+        self, data, config_scene, graphs_scene, is_cancel
+    ) -> None:
+        gcount: int = 0
+        if is_cancel():
+            raise CalculationAborted()
         if data and isinstance(data, dict) and data.get("results_df") is not None:
             names = get_graph_names_to_build(data)
-            total = len(names)
-            if total > 0:
-                config_scene.set_progress(0, total, "Loading graphs...")
-        graphs, cfg = graphs_scene.build_graphs_with_progress(data, progress_callback)
+            gcount = len(names)
+            if gcount == 0:
+                graphs, cfg = graphs_scene.build_graphs_with_progress(
+                    data, lambda n, t, g: None, is_cancelled=is_cancel
+                )
+            else:
+                _st = [2 + 2 * gcount + 2]
+                config_scene.start_progress_run()
+                config_scene.set_progress(2, _st[0], f"0/{gcount} — building graphs")
+                def _single_progress(n, total, graph_name: str) -> None:
+                    if is_cancel():
+                        raise CalculationAborted()
+                    config_scene.set_progress(2 + n, _st[0], f"{n}/{total} — {graph_name}")
+                    QApplication.processEvents()
+
+                graphs, cfg = graphs_scene.build_graphs_with_progress(
+                    data, _single_progress, is_cancelled=is_cancel
+                )
+        else:
+            graphs, cfg = graphs_scene.build_graphs_with_progress(
+                data, lambda n, t, g: None, is_cancelled=is_cancel
+            )
 
         if graphs is not None and cfg is not None:
-            config_scene.set_progress(len(graphs), len(graphs), "Loading graphs...")
-            QApplication.processEvents()
             df = data.get("results_df")
-            graphs_scene.set_graphs(
-                graphs,
-                config=cfg,
-                results_df=df if isinstance(df, pd.DataFrame) else None,
-            )
+            n_fig = count_figures_in_graph_dict(graphs) if isinstance(graphs, dict) else 0
+            st_final = 2 + gcount + n_fig + 2
+
+            def _save_p(i, nt, name):
+                if is_cancel():
+                    raise CalculationAborted()
+                config_scene.set_progress(2 + gcount + i, st_final, f"Saving {i}/{nt}  —  {name}")
+                QApplication.processEvents()
+
+            def _prep():
+                if is_cancel():
+                    raise CalculationAborted()
+                config_scene.set_progress(2 + gcount + n_fig + 1, st_final, "Preparing graph viewer…")
+                QApplication.processEvents()
+
+            set_graphs_kw: dict = {}
+            if gcount > 0:
+                set_graphs_kw = {
+                    "save_progress": _save_p,
+                    "on_preparing_viewer": _prep,
+                    "is_cancelled": is_cancel,
+                }
+            try:
+                graphs_scene.set_graphs(
+                    graphs,
+                    config=cfg,
+                    results_df=df if isinstance(df, pd.DataFrame) else None,
+                    **set_graphs_kw,
+                )
+            except CalculationAborted:
+                raise
             try:
                 graphs_scene.set_context(
                     csv_id=data.get("csv_path") if isinstance(data, dict) else None,
@@ -522,14 +682,21 @@ class MainShellWindow(QMainWindow):
                 )
             except Exception:
                 pass
-            self._persist_calculation_succeeded()
-            self._show_view_output_panel()
+            QApplication.processEvents()
+            if gcount > 0:
+                config_scene.set_progress(st_final, st_final, "Ready")
+                QApplication.processEvents()
+                self._deferred_view_output_after_ready(config_scene)
+            else:
+                self._persist_calculation_succeeded()
+                self._show_view_output_panel()
         else:
             graphs_scene.set_data(data)
             self._view_output_sidebar_unlocked = True
             self._show_view_output_panel()
             self._refresh_sidebar_capabilities()
-        config_scene.set_progress(0, 0, "")
+        if not (graphs is not None and cfg is not None and gcount > 0):
+            config_scene.set_progress(0, 0, "")
 
     def _toggle_theme(self) -> None:
         self.current_theme = "dark" if self.current_theme == "light" else "light"

--- a/src/ui/popup_panels/config_generator_widget.py
+++ b/src/ui/popup_panels/config_generator_widget.py
@@ -7,7 +7,8 @@ import sys
 from pathlib import Path
 from typing import Optional
 
-from PyQt5.QtCore import Qt, pyqtSignal
+from PyQt5.QtCore import Qt, pyqtSignal, QRect
+from PyQt5.QtGui import QCursor, QFontMetrics
 from PyQt5.QtWidgets import (
     QButtonGroup,
     QCheckBox,
@@ -25,11 +26,15 @@ from PyQt5.QtWidgets import (
     QScrollArea,
     QSizePolicy,
     QStackedWidget,
+    QStyle,
+    QStyleOptionComboBox,
+    QToolTip,
     QVBoxLayout,
     QWidget,
 )
 
 from core.validation import generate_json
+from ui.components.bodypart_pool_list import BodypartPaletteList, BodypartSequenceList, ChipDelegate
 from app_platform.paths import sessions_dir
 
 
@@ -118,6 +123,8 @@ class ConfigGeneratorScene(QWidget):
 
         body_content = QWidget()
         body_content.setSizePolicy(QSizePolicy.Preferred, QSizePolicy.Preferred)
+        self._body_form_content = body_content
+        self._scroll_body = scroll_body
         form = QVBoxLayout(body_content)
         form.setSpacing(10)
         form.setContentsMargins(0, 0, 0, 0)
@@ -128,6 +135,14 @@ class ConfigGeneratorScene(QWidget):
         self.fin_l_2 = QComboBox()
         self.head_1 = QComboBox()
         self.head_2 = QComboBox()
+        self._body_part_combos = (
+            self.fin_r_1,
+            self.fin_r_2,
+            self.fin_l_1,
+            self.fin_l_2,
+            self.head_1,
+            self.head_2,
+        )
 
         for combo, label_text in [
             (self.fin_r_1, "Right Fin #1"),
@@ -138,27 +153,53 @@ class ConfigGeneratorScene(QWidget):
             (self.head_2, "Head pt2"),
         ]:
             form.addWidget(QLabel(label_text))
-            form.addWidget(combo)
+            row = QHBoxLayout()
+            row.setContentsMargins(0, 0, 0, 0)
+            row.addWidget(combo, 0)
+            row.addStretch(1)
+            form.addLayout(row)
 
         form.addWidget(_section_rule())
 
-        form.addWidget(QLabel("Spine Points"))
-        self.spine_list = QListWidget()
-        self.spine_list.setSelectionMode(QListWidget.MultiSelection)
-        self.spine_list.setMinimumHeight(120)
-        self.spine_list.setHorizontalScrollBarPolicy(Qt.ScrollBarAlwaysOff)
-        self.spine_list.setTextElideMode(Qt.ElideLeft)
-        form.addWidget(self.spine_list)
+        # 2×2: each row = [Available] [Spine|Tail] so it’s clear which palette feeds which list.
+        self.bp_available_spine = BodypartPaletteList()
+        self.bp_available_tail = BodypartPaletteList()
+        self.spine_list = BodypartSequenceList()
+        self.tail_list = BodypartSequenceList()
+        self.spine_list.set_palette(self.bp_available_spine)
+        self.tail_list.set_palette(self.bp_available_tail)
+        self.bp_available_spine.set_add_callback(self._on_palette_add_spine)
+        self.bp_available_tail.set_add_callback(self._on_palette_add_tail)
+        self.spine_list.set_return_callback(lambda _n: self._refill_available_pools())
+        self.tail_list.set_return_callback(lambda _n: self._refill_available_pools())
+        self.bp_available_spine.set_after_sequence_drop(self._refill_available_pools)
+        self.bp_available_tail.set_after_sequence_drop(self._refill_available_pools)
+        self.bp_pool_delegate_av1 = ChipDelegate(self.bp_available_spine)
+        self.bp_pool_delegate_av2 = ChipDelegate(self.bp_available_tail)
+        self.bp_pool_delegate_s = ChipDelegate(self.spine_list)
+        self.bp_pool_delegate_t = ChipDelegate(self.tail_list)
+        self.bp_available_spine.set_chip_delegate(self.bp_pool_delegate_av1)
+        self.bp_available_tail.set_chip_delegate(self.bp_pool_delegate_av2)
+        self.spine_list.set_chip_delegate(self.bp_pool_delegate_s)
+        self.tail_list.set_chip_delegate(self.bp_pool_delegate_t)
 
-        form.addWidget(_section_rule())
-
-        form.addWidget(QLabel("Tail Points"))
-        self.tail_list = QListWidget()
-        self.tail_list.setSelectionMode(QListWidget.MultiSelection)
-        self.tail_list.setMinimumHeight(120)
-        self.tail_list.setHorizontalScrollBarPolicy(Qt.ScrollBarAlwaysOff)
-        self.tail_list.setTextElideMode(Qt.ElideLeft)
-        form.addWidget(self.tail_list)
+        pools = QGridLayout()
+        pools.setHorizontalSpacing(12)
+        pools.setVerticalSpacing(10)
+        pools.addWidget(QLabel("Available (spine)"), 0, 0, Qt.AlignHCenter)
+        pools.addWidget(self.bp_available_spine, 1, 0)
+        pools.addWidget(QLabel("Spine (top → down)"), 0, 1, Qt.AlignHCenter)
+        pools.addWidget(self.spine_list, 1, 1)
+        pools.addWidget(QLabel("Available (tail)"), 2, 0, Qt.AlignHCenter)
+        pools.addWidget(self.bp_available_tail, 3, 0)
+        pools.addWidget(QLabel("Tail (top → down)"), 2, 1, Qt.AlignHCenter)
+        pools.addWidget(self.tail_list, 3, 1)
+        for c in (0, 1):
+            pools.setColumnStretch(c, 1)
+        form.addLayout(pools)
+        self._apply_chip_pool_styles()
+        self._apply_bodypart_field_widths()
+        self._polish_bodypart_combos()
 
         form.addWidget(_section_rule())
 
@@ -277,6 +318,7 @@ class ConfigGeneratorScene(QWidget):
     def resizeEvent(self, event):
         super().resizeEvent(event)
         self._update_csv_display()
+        self._apply_bodypart_field_widths()
 
     def _update_csv_display(self):
         path = (self.csv_id or self.csv_path or "").strip()
@@ -352,6 +394,8 @@ class ConfigGeneratorScene(QWidget):
             combo.blockSignals(True)
             combo.clear()
             combo.blockSignals(False)
+        self.bp_available_spine.clear()
+        self.bp_available_tail.clear()
         self.spine_list.clear()
         self.tail_list.clear()
         self._sync_angle_dropdowns(changed=None)
@@ -409,11 +453,7 @@ class ConfigGeneratorScene(QWidget):
         self._sync_angle_dropdowns(changed=None)
         self.angle_ccw.setChecked(False)
 
-        self.spine_list.clear()
-        self.tail_list.clear()
-        for bodypart in self.bodyparts:
-            self.spine_list.addItem(QListWidgetItem(bodypart))
-            self.tail_list.addItem(QListWidgetItem(bodypart))
+        self._rebuild_bodypart_pools()
         self._update_csv_display()
         self._update_tab_enabled_state()
 
@@ -519,6 +559,187 @@ class ConfigGeneratorScene(QWidget):
 
         return True, ""
 
+    def _body_content_width(self) -> int:
+        w = 400
+        if self._body_form_content is not None and self._body_form_content.width() > 80:
+            w = self._body_form_content.width()
+        elif self._stack.width() > 120:
+            w = max(200, self._stack.width() - 220)
+        return w
+
+    def _apply_bodypart_field_widths(self) -> None:
+        w = self._body_content_width()
+        fm = self.fontMetrics()
+        ch8 = max(1, fm.horizontalAdvance("0" * 8)) + 48
+        # Previously ~0.33*w; 3x that ≈ use most of the row; floor at ~8 chars.
+        min_wide = int(w * 0.33) * 3
+        combo_max = min(w - 16, max(ch8, min(w - 8, min_wide)))
+        for c in self._body_part_combos:
+            c.setMaximumWidth(16777215)  # reset
+            c.setMinimumWidth(ch8)
+            c.setMaximumWidth(combo_max)
+        col = max(160, (w - 32) // 2)
+        # Don’t cap pool lists too hard — a tight max+min pair made columns effectively zero-wide in edge layouts.
+        for pl in (self.bp_available_spine, self.bp_available_tail, self.spine_list, self.tail_list):
+            pl.setMaximumWidth(16777215)
+            pl.setMinimumWidth(min(220, col))
+
+    def _apply_chip_pool_styles(self) -> None:
+        """Rounded chip look + pool surface; :hover / :selected differ so clicks read as feedback."""
+        for obj in (self.bp_available_spine, self.bp_available_tail, self.spine_list, self.tail_list):
+            obj.setStyleSheet(
+                """
+                QListWidget {
+                    background-color: rgba(40, 40, 48, 0.85);
+                    border: 1px solid rgba(100, 100, 120, 0.9);
+                    border-radius: 8px;
+                    padding: 6px;
+                    outline: none;
+                }
+                QListWidget::item {
+                    background-color: rgba(50, 50, 60, 0.95);
+                    border: 1px solid rgba(120, 120, 140, 0.85);
+                    border-radius: 6px;
+                    padding: 4px 8px;
+                    margin: 2px;
+                }
+                QListWidget::item:hover {
+                    background-color: rgba(70, 72, 90, 0.98);
+                    border: 1px solid rgba(160, 165, 200, 0.95);
+                }
+                QListWidget::item:selected, QListWidget::item:selected:active {
+                    background-color: rgba(60, 90, 150, 0.85);
+                    border: 1px solid rgba(140, 180, 255, 0.9);
+                }
+                QListWidget::item:pressed {
+                    background-color: rgba(90, 100, 140, 0.95);
+                }
+            """
+            )
+
+    def _polish_bodypart_combos(self) -> None:
+        def _tip_from_elide(cc: QComboBox, t: str) -> None:
+            t = t or ""
+            if not t:
+                cc.setToolTip("")
+                return
+            opt = QStyleOptionComboBox()
+            opt.initFrom(cc)
+            opt.editable = False
+            opt.currentText = t
+            ar = self.style().subControlRect(QStyle.CC_ComboBox, opt, QStyle.SC_ComboBoxEditField, cc)
+            avail = max(1, ar.width() - 6)
+            fm = QFontMetrics(cc.font())
+            if fm.horizontalAdvance(t) > avail:
+                cc.setToolTip(t)
+            else:
+                cc.setToolTip("")
+
+        for combo in self._body_part_combos:
+
+            def _on_text(t: str, cc: QComboBox = combo) -> None:
+                _tip_from_elide(cc, t)
+
+            combo.currentTextChanged.connect(_on_text)
+            try:
+                v = combo.view()
+                v.setMouseTracking(True)
+
+                def _on_hov(idx, cc: QComboBox = combo) -> None:
+                    self._on_combo_list_hover(cc, idx)
+
+                v.entered.connect(_on_hov)
+            except Exception:
+                pass
+            _tip_from_elide(combo, combo.currentText())
+            combo.setMinimumContentsLength(8)
+
+    def _on_combo_list_hover(self, combo: QComboBox, index) -> None:
+        t = (combo.model().data(index, Qt.DisplayRole) or "")
+        t = str(t) if t is not None else ""
+        if t:
+            QToolTip.showText(QCursor.pos(), t, combo, QRect(), 5000)
+        else:
+            QToolTip.hideText()
+
+    def _refill_available_pools(self) -> None:
+        """Each Available list only shows bodyparts not already placed in the paired Spine or Tail list."""
+        self.bp_available_spine.clear()
+        self.bp_available_tail.clear()
+        if not self.bodyparts:
+            return
+        in_spine = {
+            (self.spine_list.item(i).text() or "").strip()
+            for i in range(self.spine_list.count())
+            if self.spine_list.item(i)
+        }
+        in_tail = {
+            (self.tail_list.item(i).text() or "").strip()
+            for i in range(self.tail_list.count())
+            if self.tail_list.item(i)
+        }
+        for bp in sorted(self.bodyparts, key=str.lower):
+            if bp not in in_spine:
+                self.bp_available_spine.addItem(QListWidgetItem(bp))
+            if bp not in in_tail:
+                self.bp_available_tail.addItem(QListWidgetItem(bp))
+
+    def _on_palette_add_spine(self, t: str) -> None:
+        n = (t or "").strip()
+        if n and self.spine_list.add_name(n):
+            self._refill_available_pools()
+
+    def _on_palette_add_tail(self, t: str) -> None:
+        n = (t or "").strip()
+        if n and self.tail_list.add_name(n):
+            self._refill_available_pools()
+
+    def _rebuild_bodypart_pools(
+        self,
+        spine_order: list | None = None,
+        tail_order: list | None = None,
+    ) -> None:
+        """Rebuild spine/tail from saved order, then each Available = bodyparts not in that list."""
+        self.bp_available_spine.clear()
+        self.bp_available_tail.clear()
+        self.spine_list.clear()
+        self.tail_list.clear()
+        if not self.bodyparts:
+            return
+        bset = set(self.bodyparts)
+        s_list: list[str] = []
+        for x in spine_order or []:
+            t = str(x)
+            if t in bset and t not in s_list:
+                s_list.append(t)
+        t_list: list[str] = []
+        for x in tail_order or []:
+            t = str(x)
+            if t in bset and t not in t_list:
+                t_list.append(t)
+        for n in s_list:
+            self.spine_list.add_name(n)
+        for n in t_list:
+            self.tail_list.add_name(n)
+        self._refill_available_pools()
+
+    def _config_namespace_dir(self) -> Path:
+        """
+        Backlog #4: each CSV gets its own folder so `config.json` names do not collide in a shared flat dir.
+        """
+        if self.current_session is None:
+            return Path(sessions_dir()) / "unnamed"
+        session_folder = Path(sessions_dir()) / self.current_session.getName()
+        session_folder.mkdir(parents=True, exist_ok=True)
+        key = self.csv_id or self.csv_path
+        if not key:
+            return session_folder
+        stem = Path(str(key)).stem
+        safe = re.sub(r"[^\w\-.]+", "_", stem).strip("_")[:80] or "csv"
+        d = session_folder / "by_csv" / safe
+        d.mkdir(parents=True, exist_ok=True)
+        return d
+
     def _next_available_path(self, folder: Path, base: str) -> Path:
         if not base.lower().endswith(".json"):
             base = base + ".json"
@@ -545,8 +766,8 @@ class ConfigGeneratorScene(QWidget):
             self._user_message("Warning: No session loaded. Start or load a session first.", tab=0)
             return
 
-        spine_points = [item.text() for item in self.spine_list.selectedItems()]
-        tail_points = [item.text() for item in self.tail_list.selectedItems()]
+        spine_points = [self.spine_list.item(i).text() for i in range(self.spine_list.count())]
+        tail_points = [self.tail_list.item(i).text() for i in range(self.tail_list.count())]
 
         if len(spine_points) < 2 or len(tail_points) < 2:
             self._user_message(
@@ -555,6 +776,18 @@ class ConfigGeneratorScene(QWidget):
             )
             return
 
+        if len(spine_points) != len(set(spine_points)):
+            self._user_message(
+                "Error: duplicate point name in Spine. Each body part can appear only once.",
+                tab=1,
+            )
+            return
+        if len(tail_points) != len(set(tail_points)):
+            self._user_message(
+                "Error: duplicate point name in Tail. Each body part can appear only once.",
+                tab=1,
+            )
+            return
         points = {
             "right_fin": [self.fin_r_1.currentText(), self.fin_r_2.currentText()],
             "left_fin": [self.fin_l_1.currentText(), self.fin_l_2.currentText()],
@@ -584,17 +817,13 @@ class ConfigGeneratorScene(QWidget):
         so["show_tail_left_fin_moving_dot_plot"] = self.chk_dot_lf_mov.isChecked()
         so["show_tail_right_fin_moving_dot_plot"] = self.chk_dot_rf_mov.isChecked()
 
-        session_name = self.current_session.getName()
-        session_folder = Path(sessions_dir()) / session_name
-        session_folder.mkdir(parents=True, exist_ok=True)
-
         config_name = self._resolved_config_name()
         ok, msg = self._validate_config_name(config_name)
         if not ok:
             self._user_message(f"Warning: {msg}", tab=0)
             return
 
-        save_path = self._next_available_path(session_folder, config_name)
+        save_path = self._next_available_path(self._config_namespace_dir(), config_name)
         save_path = str(save_path)
 
         try:
@@ -678,16 +907,7 @@ class ConfigGeneratorScene(QWidget):
             _set_combo(self.head_1, str(head.get("pt1", "")))
             _set_combo(self.head_2, str(head.get("pt2", "")))
 
-        for lst, names in (
-            (self.spine_list, pts.get("spine") or []),
-            (self.tail_list, pts.get("tail") or []),
-        ):
-            lst.clearSelection()
-            names_set = {str(n) for n in names}
-            for i in range(lst.count()):
-                it = lst.item(i)
-                if it.text() in names_set:
-                    it.setSelected(True)
+        self._rebuild_bodypart_pools(pts.get("spine") or [], pts.get("tail") or [])
 
         so = cfg.get("shown_outputs") or {}
         self.chk_fin_tail.setChecked(bool(so.get("show_angle_and_distance_plot", True)))

--- a/src/ui/popup_panels/generate_config_dialog.py
+++ b/src/ui/popup_panels/generate_config_dialog.py
@@ -47,7 +47,20 @@ class GenerateConfigDialog(QDialog):
         outer.setContentsMargins(0, 0, 0, 0)
         outer.setSpacing(0)
 
-        self._title_bar = DialogTitleBar(self, "Generate Config", self)
+        self._title_bar = DialogTitleBar(
+            self,
+            "Generate Config",
+            self,
+            help_title="Generate Config",
+            help_paragraph=(
+                "Click through the tabs to set body points, video scale, and graph options, then save so the new JSON is part of the current session. "
+                "Select & Run will use that file after you finish. "
+                "Scroll the window to reach every section."
+            ),
+            help_tips=(
+                "If the app opened this dialog with a path, some fields may already be filled from that file.",
+            ),
+        )
         outer.addWidget(self._title_bar)
         outer.addWidget(horizontal_separator())
 

--- a/src/ui/popup_panels/session_select_dialog.py
+++ b/src/ui/popup_panels/session_select_dialog.py
@@ -240,7 +240,21 @@ class SessionSelectDialog(QDialog):
         outer.setContentsMargins(0, 0, 0, 0)
         outer.setSpacing(0)
 
-        self._title_bar = DialogTitleBar(self, "Session Select", self)
+        self._title_bar = DialogTitleBar(
+            self,
+            "Session Select",
+            self,
+            help_title="Session Select",
+            help_paragraph=(
+                "Click a row in the list to open that session. "
+                "Click + Create New or Upload New to add a new session file. "
+                "Grey rows mean the file is missing or broken. "
+                "Right-click a row and select Find location… to repoint that session to a file on your disk."
+            ),
+            help_tips=(
+                "If you move or rename files on your computer, use Verify and Select & Run to fix paths if something breaks.",
+            ),
+        )
         outer.addWidget(self._title_bar)
         outer.addWidget(horizontal_separator())
 

--- a/styles/themes.py
+++ b/styles/themes.py
@@ -155,6 +155,9 @@ def apply_theme(app, theme):
             border: 1px solid {line};
             border-radius: 8px;
         }}
+        QTreeWidget#ConfigSelectionTree::item {{
+            border: none;
+        }}
         QTreeWidget#ConfigSelectionTree::item:selected {{
             background-color: {cb};
             color: {tx};
@@ -166,8 +169,8 @@ def apply_theme(app, theme):
         QTreeWidget#ConfigSelectionTree::branch:closed:has-children:has-siblings,
         QTreeWidget#ConfigSelectionTree::branch:open:has-children:has-siblings,
         QTreeWidget#ConfigSelectionTree::branch:open:has-children:!has-siblings {{
-            background-color: {tmenu};
-            border-radius: 2px;
+            background-color: transparent;
+            border: none;
         }}
         QTreeWidget#ConfigSelectionTree QHeaderView::section {{
             background-color: {pc};
@@ -269,11 +272,53 @@ def apply_theme(app, theme):
             background-color: {gv_tab_bg};
             color: {tmu};
         }}
+        /* Compare tab — left controls column scrolls when selectors are tall (multi-CSV, long names) */
+        QWidget#WorkspaceMain QScrollArea#GraphViewerCompareLeftScroll {{
+            background-color: {pm};
+            border: 1px solid {line};
+            border-radius: 8px;
+        }}
+        QWidget#WorkspaceMain QScrollArea#GraphViewerCompareLeftScroll QScrollBar:vertical {{
+            background-color: {pm};
+            width: 10px;
+            border: none;
+        }}
+        QWidget#WorkspaceMain QScrollArea#GraphViewerCompareLeftScroll QScrollBar::handle:vertical {{
+            background-color: {cb};
+            border-radius: 4px;
+            margin: 2px;
+        }}
+        QWidget#WorkspaceMain QScrollArea#GraphViewerCompareLeftScroll QScrollBar::handle:vertical:hover {{
+            background-color: {line};
+        }}
+        QWidget#WorkspaceMain QScrollArea#GraphViewerCompareLeftScroll QScrollBar::groove:vertical {{
+            background-color: {pm};
+            border: none;
+        }}
+        QWidget#WorkspaceMain QScrollArea#GraphViewerCompareLeftScroll QScrollBar::add-line:vertical,
+        QWidget#WorkspaceMain QScrollArea#GraphViewerCompareLeftScroll QScrollBar::sub-line:vertical {{
+            height: 0px;
+        }}
 
         QDialog#GenerateConfigDialog {{
             background-color: {pm};
             color: {tx};
             border: 1px solid {line};
+        }}
+        QDialog#SceneHelpDialog {{
+            background-color: {pm};
+            color: {tx};
+            border: 1px solid {line};
+        }}
+        QDialog#SceneHelpDialog QWidget#SceneHelpDialogBody {{
+            background-color: {pm};
+            color: {tx};
+        }}
+        QDialog#SceneHelpDialog QPlainTextEdit#SceneHelpDialogText {{
+            background-color: {pm};
+            color: {tx};
+            border: none;
+            selection-background-color: {cb};
         }}
         QWidget#GenerateConfigBody {{
             background-color: {pm};
@@ -537,6 +582,29 @@ def apply_theme(app, theme):
         QToolButton#SidebarTool[activeTool="true"]:disabled {{
             background-color: transparent;
             border: 1px solid transparent;
+        }}
+
+        /* #94 — help (ⓘ) on main scenes, graph context bar, and DialogTitleBar */
+        QToolButton#SceneHelpButton {{
+            background-color: transparent;
+            color: {tmu};
+            border: 1px solid transparent;
+            border-radius: 14px;
+            min-width: 28px;
+            max-width: 28px;
+            min-height: 28px;
+            max-height: 28px;
+            font-size: 14px;
+            font-weight: bold;
+            padding: 0px;
+        }}
+        QToolButton#SceneHelpButton:hover {{
+            background-color: {cb};
+            color: {tmenu_h};
+            border: 1px solid {line};
+        }}
+        QToolButton#SceneHelpButton:pressed {{
+            background-color: {line};
         }}
 
         QWidget#ErrorToast {{

--- a/tests/unit/core/calculations/test_Driver.py
+++ b/tests/unit/core/calculations/test_Driver.py
@@ -2,6 +2,9 @@ import numpy as np
 import numpy.testing as npt
 import pandas as pd
 
+import pytest
+
+from cvzebrafish.core.calculations.cancelled import CalculationAborted
 from cvzebrafish.core.calculations.Driver import run_calculations
 
 
@@ -58,6 +61,13 @@ def _build_config():
         "auto_find_time_ranges": False,
         "time_ranges": [[0, 2]],
     }
+
+
+def test_run_calculations_respects_cancel_check():
+    parsed_points = _build_parsed_points()
+    config = _build_config()
+    with pytest.raises(CalculationAborted):
+        run_calculations(parsed_points, config, cancel_check=lambda: True)
 
 
 def test_run_calculations_returns_expected_dataframe():


### PR DESCRIPTION
- Implemented compare tab in graph viewer for two graphs side by side
- Implemented single progress bar with run, stop, and cancel
- Implemented scene help icons and themed help windows to show hidden features on top of standard ones
- Implemented generate config body part pools with available versus spine and tail and per csv config folders
- Updated folder structure alongside making CSV copies stored in session folders
- Updated theme and layout styling for the new UI pieces
- Issue #91, #92, and #94 are resolved here.
- Fixed non-issue bugs noted during last meeting

## Summary
What does this change do and why?

## Testing
- [ ] `pytest`
- [ ] Manual UI walkthrough (describe)
- [ ] Other (describe)

## Checklist
- [ ] Docs updated (README/how-to/notes)
- [ ] Tests added/updated
- [ ] No breaking changes without migration notes
